### PR TITLE
fix: require http/https scheme for HTTPS relay target

### DIFF
--- a/webui/frontend/src/lib/components/AddModal.svelte
+++ b/webui/frontend/src/lib/components/AddModal.svelte
@@ -59,7 +59,8 @@
     const idx = e.target.value;
     if (idx === '') return;
     const t = targets[parseInt(idx)];
-    target = t.host ? (t.port ? `${t.host}:${t.port}` : t.host) : '';
+    const raw = t.host ? (t.port ? `${t.host}:${t.port}` : t.host) : '';
+    target = raw && httpRelay ? `http://${raw}` : raw;
   }
 
   // Parse "host:port" → { host, port } or null on failure.
@@ -125,6 +126,10 @@
     }
     if (!target.trim()) {
       showToast('danger', 'Target is required');
+      return;
+    }
+    if (!/^https?:\/\//i.test(target.trim())) {
+      showToast('danger', 'Target must start with http:// or https://');
       return;
     }
     if (!listenPort) {
@@ -256,7 +261,7 @@
           id="relay-target"
           type="text"
           bind:value={target}
-          placeholder="e.g. 192.168.1.10:3000"
+          placeholder={httpRelay ? "e.g. http://192.168.1.10:3000" : "e.g. 192.168.1.10:3000"}
           class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
         />
       </div>

--- a/webui/internal/handlers/caddy_test.go
+++ b/webui/internal/handlers/caddy_test.go
@@ -217,6 +217,70 @@ func TestCaddyHandler_Create_Success(t *testing.T) {
 	}
 }
 
+func TestCaddyHandler_Create_BareHostPort(t *testing.T) {
+	h, _ := newTestCaddyHandler(t)
+	body := jsonBody(t, config.CaddyProxy{
+		Hostname: "new.ts.net",
+		Port:     8090,
+		Target:   "mempool.embassy:8080",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/caddy/create", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.Create(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bare host:port target, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "http or https") {
+		t.Errorf("expected error mentioning 'http or https', got %q", rr.Body.String())
+	}
+}
+
+func TestCaddyHandler_Create_EmptyTarget(t *testing.T) {
+	h, _ := newTestCaddyHandler(t)
+	body := jsonBody(t, config.CaddyProxy{
+		Hostname: "new.ts.net",
+		Port:     8090,
+		Target:   "",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/caddy/create", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.Create(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty target, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "target is required") {
+		t.Errorf("expected error mentioning 'target is required', got %q", rr.Body.String())
+	}
+}
+
+func TestCaddyHandler_Create_HttpsTarget(t *testing.T) {
+	h, _ := newTestCaddyHandler(t)
+	body := jsonBody(t, config.CaddyProxy{
+		Hostname: "new.ts.net",
+		Port:     8090,
+		Target:   "https://mempool.embassy:8080",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/caddy/create", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.Create(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for https:// target, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "success" {
+		t.Errorf("expected status=success, got %v", resp["status"])
+	}
+}
+
 // --- Update ---
 
 func TestCaddyHandler_Update_WrongMethod(t *testing.T) {
@@ -240,6 +304,40 @@ func TestCaddyHandler_Update_MissingID(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for missing id, got %d", rr.Code)
+	}
+}
+
+func TestCaddyHandler_Update_BareHostPort(t *testing.T) {
+	h, _ := newTestCaddyHandler(t)
+
+	// Create a valid proxy first.
+	createBody := jsonBody(t, config.CaddyProxy{
+		ID:      "upd-scheme",
+		Port:    8095,
+		Target:  "http://localhost:9095",
+		Enabled: true,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/caddy/create", createBody)
+	createReq.Header.Set("Content-Type", "application/json")
+	h.Create(httptest.NewRecorder(), createReq)
+
+	// Attempt update with bare host:port target.
+	updateBody := jsonBody(t, config.CaddyProxy{
+		ID:      "upd-scheme",
+		Port:    8095,
+		Target:  "mempool.embassy:8080",
+		Enabled: true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/caddy/update", updateBody)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.Update(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bare host:port target on update, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "http or https") {
+		t.Errorf("expected error mentioning 'http or https', got %q", rr.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Presets populated in the HTTPS relay form now automatically prepend `http://` to the filled target value, preventing bare `host:port` from being submitted to Caddy
- Target input placeholder is now context-aware: shows `http://192.168.1.10:3000` for HTTPS relays and `192.168.1.10:3000` for TCP relays
- `saveProxy()` now validates the scheme client-side and shows a clear toast error instead of letting the opaque Caddy 400 surface to the user

## Tests added (`caddy_test.go`)

| Test | Scenario | Expected |
|---|---|---|
| `TestCaddyHandler_Create_BareHostPort` | `mempool.embassy:8080` | 400, message contains `http or https` |
| `TestCaddyHandler_Create_EmptyTarget` | `""` | 400, message contains `target is required` |
| `TestCaddyHandler_Create_HttpsTarget` | `https://mempool.embassy:8080` | 200, `status=success` |
| `TestCaddyHandler_Update_BareHostPort` | bare host:port on update | 400, message contains `http or https` |

Closes the UX gap reported where selecting a preset loaded `host:port` without a scheme, causing a confusing 400 from Caddy on submit.