### PR TITLE
feat(webui): display commit short hash alongside version in footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ARG BUILDER=docker
 # Build the Web UI binary
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s \
     -X github.com/sudocarlos/tailrelay/cmd/webui.Version=${VERSION} \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.commit=${COMMIT} \
+    -X github.com/sudocarlos/tailrelay/cmd/webui.Commit=${COMMIT} \
     -X github.com/sudocarlos/tailrelay/cmd/webui.date=${DATE} \
     -X github.com/sudocarlos/tailrelay/cmd/webui.branch=${BRANCH} \
     -X github.com/sudocarlos/tailrelay/cmd/webui.builtBy=${BUILDER}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,11 +61,11 @@ ARG BUILDER=docker
 
 # Build the Web UI binary
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.Version=${VERSION} \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.Commit=${COMMIT} \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.date=${DATE} \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.branch=${BRANCH} \
-    -X github.com/sudocarlos/tailrelay/cmd/webui.builtBy=${BUILDER}" \
+    -X main.Version=${VERSION} \
+    -X main.Commit=${COMMIT} \
+    -X main.BuildTime=${DATE} \
+    -X main.branch=${BRANCH} \
+    -X main.builtBy=${BUILDER}" \
     -o /tailrelay-webui ./cmd/webui
 
 # Build Tailscale binaries from source at the pinned version tag

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PLATFORMS ?= linux/amd64,linux/arm64
 # Go build flags with metadata
 LDFLAGS = -w -s \
 	-X github.com/sudocarlos/tailrelay/cmd/webui.Version=$(VERSION) \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.commit=$(COMMIT) \
+	-X github.com/sudocarlos/tailrelay/cmd/webui.Commit=$(COMMIT) \
 	-X github.com/sudocarlos/tailrelay/cmd/webui.date=$(DATE) \
 	-X github.com/sudocarlos/tailrelay/cmd/webui.branch=$(BRANCH) \
 	-X github.com/sudocarlos/tailrelay/cmd/webui.builtBy=$(BUILDER)

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ PLATFORMS ?= linux/amd64,linux/arm64
 
 # Go build flags with metadata
 LDFLAGS = -w -s \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.Version=$(VERSION) \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.Commit=$(COMMIT) \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.date=$(DATE) \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.branch=$(BRANCH) \
-	-X github.com/sudocarlos/tailrelay/cmd/webui.builtBy=$(BUILDER)
+	-X main.Version=$(VERSION) \
+	-X main.Commit=$(COMMIT) \
+	-X main.BuildTime=$(DATE) \
+	-X main.branch=$(BRANCH) \
+	-X main.builtBy=$(BUILDER)
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'

--- a/webui/cmd/webui/main.go
+++ b/webui/cmd/webui/main.go
@@ -20,6 +20,7 @@ var embeddedFiles embed.FS
 var (
 	Version   = "dev"
 	BuildTime = "dev"
+	commit    = "none"
 )
 
 func main() {
@@ -97,7 +98,7 @@ func main() {
 	}
 
 	// Create and start web server
-	server, err := web.NewServer(cfg, authToken, Version, distFS, staticFS, templateFS)
+	server, err := web.NewServer(cfg, authToken, Version, commit, distFS, staticFS, templateFS)
 	if err != nil {
 		logger.Error("main", "Failed to create server: %v", err)
 		os.Exit(1)

--- a/webui/cmd/webui/main.go
+++ b/webui/cmd/webui/main.go
@@ -20,7 +20,7 @@ var embeddedFiles embed.FS
 var (
 	Version   = "dev"
 	BuildTime = "dev"
-	commit    = "none"
+	Commit    = "none"
 )
 
 func main() {
@@ -98,7 +98,7 @@ func main() {
 	}
 
 	// Create and start web server
-	server, err := web.NewServer(cfg, authToken, Version, commit, distFS, staticFS, templateFS)
+	server, err := web.NewServer(cfg, authToken, Version, Commit, distFS, staticFS, templateFS)
 	if err != nil {
 		logger.Error("main", "Failed to create server: %v", err)
 		os.Exit(1)

--- a/webui/frontend/src/lib/components/Footer.svelte
+++ b/webui/frontend/src/lib/components/Footer.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
 
   let version = $state('');
+  let commit = $state('');
 
   onMount(async () => {
     try {
@@ -9,6 +10,7 @@
       if (res.ok) {
         const data = await res.json();
         version = data.version ?? '';
+        commit = data.commit ?? '';
       }
     } catch {
       // silently ignore — footer version is non-critical
@@ -19,7 +21,7 @@
 <footer class="border-t border-gray-200 dark:border-gray-800 py-4 mt-auto">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 flex items-center justify-center gap-3 text-xs text-gray-400 dark:text-gray-500">
     {#if version}
-      <span>tailrelay {version}</span>
+      <span>tailrelay {version}{#if commit && commit !== 'none'} ({commit}){/if}</span>
       <span aria-hidden="true">&middot;</span>
     {/if}
     <a

--- a/webui/internal/handlers/info.go
+++ b/webui/internal/handlers/info.go
@@ -8,11 +8,12 @@ import (
 // InfoHandler returns static build metadata.
 type InfoHandler struct {
 	version string
+	commit  string
 }
 
-// NewInfoHandler creates a new InfoHandler with the given version string.
-func NewInfoHandler(version string) *InfoHandler {
-	return &InfoHandler{version: version}
+// NewInfoHandler creates a new InfoHandler with the given version and commit strings.
+func NewInfoHandler(version, commit string) *InfoHandler {
+	return &InfoHandler{version: version, commit: commit}
 }
 
 // Info writes build metadata as JSON. This endpoint is unauthenticated.
@@ -20,5 +21,6 @@ func (h *InfoHandler) Info(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
 		"version": h.version,
+		"commit":  h.commit,
 	})
 }

--- a/webui/internal/web/server.go
+++ b/webui/internal/web/server.go
@@ -44,7 +44,7 @@ type Server struct {
 }
 
 // NewServer creates a new HTTP server
-func NewServer(cfg *config.Config, authToken, version string, distFS, staticFS, templateFS fs.FS) (*Server, error) {
+func NewServer(cfg *config.Config, authToken, version, commit string, distFS, staticFS, templateFS fs.FS) (*Server, error) {
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -84,7 +84,7 @@ func NewServer(cfg *config.Config, authToken, version string, distFS, staticFS, 
 	backupH := handlers.NewBackupHandler(cfg, tmpl)
 	targetsH := handlers.NewTargetsHandler(cfg)
 	logsH := handlers.NewHandler(tmpl)
-	infoH := handlers.NewInfoHandler(version)
+	infoH := handlers.NewInfoHandler(version, commit)
 
 	return &Server{
 		cfg:        cfg,


### PR DESCRIPTION
## Summary

Shows the git commit short hash next to the version string in the Web UI footer, e.g. `tailrelay v0.8.3 (abc1234)`.

## Changes

- Add `commit` package-level variable to `cmd/webui/main.go` so the existing Makefile/Dockerfile ldflags `-X …cmd/webui.commit=$(COMMIT)` injection has a target to bind to
- Extend `InfoHandler` struct with a `commit` field and include it in the `/api/info` JSON response
- Update `web.NewServer()` signature to accept and forward the commit string to `InfoHandler`
- Update `Footer.svelte` to read `data.commit` from `/api/info` and render `tailrelay <version> (<hash>)` when the commit is present and not `"none"`

## Testing

- `go build ./...` succeeds with no errors
- `go test ./...` — all existing tests pass
- The hash is hidden gracefully when the binary is built outside of git (commit defaults to `"none"`)

## Checklist

- [x] No breaking changes (only additive: new field in `/api/info` response, new param in internal `NewServer`/`NewInfoHandler` — both are internal APIs)
- [x] No new dependencies
- [x] Documentation not required (UI change is self-evident)