### PR TITLE
ci: automate GitHub release and Docker Hub/GHCR push on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
   release:
@@ -86,3 +87,80 @@ jobs:
           TAILRELAY_HOST: tailrelay-test
           TAILNET_DOMAIN: example.com
           COMPOSE_FILE: compose-test.yml
+
+  release:
+    needs: [frontend, backend, integration]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Frontend Dependencies
+        working-directory: webui/frontend
+        run: npm install
+
+      - name: Build Frontend
+        working-directory: webui/frontend
+        run: npm run build
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.head_commit.timestamp }}
+            BRANCH=main
+            BUILDER=github-actions
+          tags: |
+            sudocarlos/tailrelay:${{ github.ref_name }}
+            sudocarlos/tailrelay:latest
+            ghcr.io/sudocarlos/tailrelay:${{ github.ref_name }}
+            ghcr.io/sudocarlos/tailrelay:latest
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.notes }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary

- Adds a `v*.*.*` tag trigger so all existing CI jobs run on tagged pushes
- Adds a new `release` job that runs only on tag pushes, after `frontend`, `backend`, and `integration` all pass
- Extracts the matching `CHANGELOG.md` section as GitHub Release notes
- Builds a multi-platform image (`linux/amd64`, `linux/arm64`) and pushes `vX.Y.Z` + `latest` tags to both Docker Hub (`sudocarlos/tailrelay`) and GHCR (`ghcr.io/sudocarlos/tailrelay`)
- Creates a GitHub Release via `softprops/action-gh-release@v2`

## Required secrets (already configured)

| Secret | Purpose |
|--------|---------|
| `DOCKERHUB_USERNAME` | Docker Hub login |
| `DOCKERHUB_TOKEN` | Docker Hub access token |

`GITHUB_TOKEN` is provided automatically by Actions for GHCR auth and release creation.

## Release flow

```
git tag v0.8.5 && git push origin v0.8.5
```

1. `frontend` + `backend` + `integration` jobs run in parallel
2. On all three passing, `release` job:
   - Extracts `[0.8.5]` section from `CHANGELOG.md` as release body
   - Builds and pushes `sudocarlos/tailrelay:v0.8.5` + `:latest` to Docker Hub and GHCR
   - Creates GitHub Release `v0.8.5` with the changelog notes