### PR TITLE
fix(serve): address PR #23 Copilot review items

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: b7ce114
+reviewed_at: f7df402
 ---
 
 # Docker & CI Pipeline
@@ -20,16 +20,14 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 
 `Dockerfile` stages:
 1. **frontend-builder** (`node:{NODE_VERSION}-alpine`) — builds Vite/Svelte/Tailwind SPA assets; injects `VERSION` via `npm version`
-2. **caddy-builder** (`golang:{GO_VERSION}-alpine`) — clones `caddyserver/caddy` at `v{CADDY_VERSION}` and compiles the `caddy` binary
-3. **webui-builder** (`golang:{GO_VERSION}-alpine`) — builds the tailrelay-webui Go binary; copies frontend dist from `frontend-builder`
-4. **tailscale-builder** (`golang:{GO_VERSION}-alpine`) — builds Tailscale binaries from source via `go install tailscale.com/cmd/...@{TAILSCALE_VERSION}`
-5. **binary-dev** (`scratch`) — holds a pre-built local binary from `./data/tailrelay-webui` for dev builds
-6. **binary-source** — selector stage; resolves to `webui-builder` (default) or `binary-dev` via `WEBUI_SOURCE` build arg
-7. **main** (`alpine:{ALPINE_VERSION}`) — installs runtime deps (iptables, iproute2, socat, mailcap), copies all binaries from builder stages; restores legacy iptables symlinks for broad host compatibility
+2. **webui-builder** (`golang:{GO_VERSION}-alpine`) — builds the tailrelay-webui Go binary; copies frontend dist from `frontend-builder`
+3. **tailscale-builder** (`golang:{GO_VERSION}-alpine`) — builds Tailscale binaries from source via `go install tailscale.com/cmd/...@{TAILSCALE_VERSION}`
+4. **binary-dev** (`scratch`) — holds a pre-built local binary from `./data/tailrelay-webui` for dev builds
+5. **binary-source** — selector stage; resolves to `webui-builder` (default) or `binary-dev` via `WEBUI_SOURCE` build arg
+6. **main** (`alpine:{ALPINE_VERSION}`) — installs runtime deps (iptables, iproute2, mailcap), copies all binaries from builder stages; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
 - `TAILSCALE_VERSION` (default: `v1.96.5`) — version tag passed to `go install tailscale.com/cmd/...@${TAILSCALE_VERSION}`
-- `CADDY_VERSION` (default: `2.11.3`) — version tag used for `git clone --branch v${CADDY_VERSION} caddyserver/caddy`
 - `GO_VERSION` (default: `1.26.1`)
 - `NODE_VERSION` (default: `24`)
 - `ALPINE_VERSION` (default: `3.22`)
@@ -124,8 +122,6 @@ make integration-test   # pytest tests/integration/ -v
 
 | Endpoint | Port | Service |
 |----------|------|---------|
-| HTTP proxy | `:8080`, `:8081` | Caddy |
-| HTTPS proxy | `:8443` | Caddy |
 | Health check | `:9002/healthz` | Tailscale |
 | Metrics | `:9002/metrics` | Tailscale |
 | Web UI | `:8021` | Web UI |
@@ -144,11 +140,8 @@ make integration-test
 
 `start.sh` orchestrates all services:
 1. Start `tailscaled` (userspace networking)
-2. Start Caddy (with Caddyfile)
-3. Wait 1 second for Caddy API
-4. Start Web UI
-5. Spawn socat relays (if `RELAY_LIST` set)
-6. `wait` on tailscaled + webui PIDs
+2. Start Web UI
+3. `wait` on tailscaled + webui PIDs
 
 Handles `SIGTERM`/`SIGINT` for graceful shutdown.
 
@@ -166,6 +159,5 @@ Handles `SIGTERM`/`SIGINT` for graceful shutdown.
 |-----------|---------|
 | Container | `v0.8.8` (see `start.sh`) |
 | Tailscale | `v1.96.5` (built from source via `go install tailscale.com/cmd/...`) |
-| Caddy | `2.11.3` (built from source via `git clone caddyserver/caddy`) |
 | Go | `1.26.1` (Dockerfile ARG) |
 | Node.js (CI) | `20` (GitHub Actions) / `24` (Dockerfile ARG) |

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: documentation
 description: Updating all tailrelay documentation — README, CHANGELOG, release notes, AGENTS.md, SKILL.md files, and webui/README.md. Use when adding user-facing features, releasing a new version, updating component versions, or when any doc's reviewed_at SHA is out of date with HEAD.
-reviewed_at: b7ce114
+reviewed_at: f7df402
 ---
 
 # Documentation
@@ -222,8 +222,7 @@ git log --oneline 17791f3..HEAD -- webui/ Makefile
 
 | Skill | File | Covers |
 |-------|------|--------|
-| `caddy-proxy-management` | `.agents/skills/caddy/SKILL.md` | `webui/internal/caddy/`, `webui/internal/handlers/caddy.go` |
-| `socat-relay-management` | `.agents/skills/socat/SKILL.md` | `webui/internal/socat/`, `webui/internal/handlers/socat.go` |
+| `serve-relay-management` | `.agents/skills/serve/SKILL.md` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `webui-development` | `.agents/skills/webui/SKILL.md` | `webui/`, `Makefile` |
 | `docker-ci-pipeline` | `.agents/skills/docker-ci/SKILL.md` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
 | `tailscale-management` | `.agents/skills/tailscale/SKILL.md` | `webui/internal/tailscale/`, `start.sh` |
@@ -293,39 +292,35 @@ A full review must inspect every skill file, not just the ones whose covered pat
 
 Work through every skill in this order:
 
-1. **`caddy-proxy-management`** — `.agents/skills/caddy/SKILL.md`
-   - Covers: `webui/internal/caddy/`, `webui/internal/handlers/caddy.go`
-   - Check: proxy target format, dial field, route IDs, Admin API patterns, TLS cert handling
+1. **`serve-relay-management`** — `.agents/skills/serve/SKILL.md`
+   - Covers: `webui/internal/serve/`, `webui/internal/handlers/serve.go`
+   - Check: relay types, ErrTailscaleNotReady, reconcile flow, API endpoints
 
-2. **`socat-relay-management`** — `.agents/skills/socat/SKILL.md`
-   - Covers: `webui/internal/socat/`, `webui/internal/handlers/socat.go`
-   - Check: RELAY_LIST format, validation rules, exec.Command invocation, relay lifecycle
-
-3. **`webui-development`** — `.agents/skills/webui/SKILL.md`
+2. **`webui-development`** — `.agents/skills/webui/SKILL.md`
    - Covers: `webui/`, `Makefile`
    - Check: build workflow, handler structure, auth flow, frontend SPA build
 
-4. **`docker-ci-pipeline`** — `.agents/skills/docker-ci/SKILL.md`
+3. **`docker-ci-pipeline`** — `.agents/skills/docker-ci/SKILL.md`
    - Covers: `Dockerfile`, `.github/workflows/`, `compose-test.yml`
-   - Check: pinned versions (Go, Node, Alpine, Tailscale, Caddy, socat), CI job names, Make targets
+   - Check: pinned versions (Go, Node, Alpine, Tailscale), CI job names, Make targets
 
-5. **`tailscale-management`** — `.agents/skills/tailscale/SKILL.md`
+4. **`tailscale-management`** — `.agents/skills/tailscale/SKILL.md`
    - Covers: `webui/internal/tailscale/`, `start.sh`
    - Check: CLI wrapper methods, StatusCache, auth key handling, start.sh version
 
-6. **`security-review`** — `.agents/skills/security-review/SKILL.md`
+5. **`security-review`** — `.agents/skills/security-review/SKILL.md`
    - Covers: all security-relevant code paths
    - Check: known findings, checklist items, any new auth/input/backup code
 
-7. **`testing-cicd`** — `.agents/skills/testing-cicd/SKILL.md`
+6. **`testing-cicd`** — `.agents/skills/testing-cicd/SKILL.md`
    - Covers: `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml`
    - Check: test package list, CI job names, integration test structure
 
-8. **`git-workflow`** — `.agents/skills/git-workflow/SKILL.md`
+7. **`git-workflow`** — `.agents/skills/git-workflow/SKILL.md`
    - Covers: commit conventions, branch naming
    - Check: commit types, branch format, PR template
 
-9. **`documentation`** — `.agents/skills/documentation/SKILL.md` (this file)
+8. **`documentation`** — `.agents/skills/documentation/SKILL.md` (this file)
    - Covers: all docs
    - Check: skill file table completeness, review workflow accuracy
 

--- a/.agents/skills/serve/SKILL.md
+++ b/.agents/skills/serve/SKILL.md
@@ -92,23 +92,22 @@ var ErrTailscaleNotReady = fmt.Errorf("tailscale not ready")
 Returned by `Reconcile()` (and transitively by `UpsertRelay`, `DeleteRelay`,
 `ToggleRelay`) when Tailscale is not yet authenticated or connected.
 
-**Callers must use `errors.Is` to distinguish this from real failures:**
+### `ErrRelayNotFound`
 
 ```go
-if err := manager.UpsertRelay(relay); err != nil {
-    if errors.Is(err, serve.ErrTailscaleNotReady) {
-        // relay config saved; return 202 Accepted so UI shows pending state
-        w.WriteHeader(http.StatusAccepted)
-        return
-    }
-    http.Error(w, err.Error(), http.StatusInternalServerError)
-    return
-}
+var ErrRelayNotFound = fmt.Errorf("relay not found")
 ```
 
-Relay config is persisted before `Reconcile()` is called, so a deferred
-reconcile does not lose data — it is applied on the next successful reconcile
-(e.g. after Tailscale authenticates or `IsTailscaleReady()` returns true).
+Returned by `DeleteRelay` and `ToggleRelay` when no relay with the given ID
+exists in `serve_relays.json`. Use `errors.Is` to distinguish from
+`ErrTailscaleNotReady` or internal errors.
+
+**Callers use `errors.Is` via `writeServeResult`:**
+
+```go
+writeServeResult(w, manager.DeleteRelay(id), "Relay deleted successfully")
+// nil → 200, ErrTailscaleNotReady → 202, ErrRelayNotFound → 404, other → 500
+```
 
 ### Reconciliation Flow
 
@@ -161,7 +160,8 @@ These shims are registered before protected routes and do not require auth.
 ### `writeServeResult` Helper
 
 All mutating handlers use the `writeServeResult(w, err, msg)` helper which
-maps `nil` → 200, `ErrTailscaleNotReady` → 202, and other errors → 500.
+maps `nil` → 200, `ErrTailscaleNotReady` → 202, `ErrRelayNotFound` → 404,
+and other errors → 500.
 
 ## Migration from Legacy Configs
 

--- a/.agents/skills/serve/SKILL.md
+++ b/.agents/skills/serve/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: serve-relay-management
+description: tailscale serve relay management — HTTPS and TCP relay types, serve_relays.json format, reconciliation flow, API endpoints, migration from legacy caddy/socat configs, and ErrTailscaleNotReady handling. Use when working with internal/serve/, handlers/serve.go, or /api/serve/* endpoints.
+reviewed_at: f7df402
+---
+
+# Serve Relay Management
+
+## Overview
+
+`internal/serve/` implements relay orchestration backed by `tailscale serve`.
+It replaces the former Caddy (HTTPS) and socat (TCP) relay stacks.
+Relay state is persisted to `serve_relays.json` and reconciled with
+`tailscale serve` on startup and after every mutating operation.
+
+## Relay Types
+
+| Type    | Transport        | `tailscale serve` command         |
+|---------|------------------|-----------------------------------|
+| `https` | HTTPS termination | `tailscale serve https:<port> ...` |
+| `tcp`   | Raw TCP forward   | `tailscale serve tcp:<port> tcp://...` |
+
+## `serve_relays.json` Format
+
+Default path: `/var/lib/tailscale/serve_relays.json` (configurable via
+`paths.serve_relay_config` in `webui.yaml`).
+
+```json
+{
+  "relays": [
+    {
+      "id": "https-443",
+      "type": "https",
+      "hostname": "myhost.example.ts.net",
+      "listen_port": 443,
+      "target_host": "192.168.1.10",
+      "target_port": 8080,
+      "target_https": false,
+      "enabled": true,
+      "autostart": true
+    },
+    {
+      "id": "tcp-2222",
+      "type": "tcp",
+      "listen_port": 2222,
+      "target_host": "192.168.1.20",
+      "target_port": 22,
+      "enabled": true,
+      "autostart": true
+    }
+  ]
+}
+```
+
+## Key Types (`webui/internal/config/types.go`)
+
+```go
+type ServeRelay struct {
+    ID          string `json:"id"`
+    Type        string `json:"type"`          // "https" or "tcp"
+    Hostname    string `json:"hostname,omitempty"`
+    ListenPort  int    `json:"listen_port"`
+    TargetHost  string `json:"target_host"`
+    TargetPort  int    `json:"target_port"`
+    TargetHTTPS bool   `json:"target_https"`
+    Enabled     bool   `json:"enabled"`
+    Autostart   bool   `json:"autostart"`
+}
+```
+
+## Manager (`webui/internal/serve/manager.go`)
+
+### Public API
+
+| Method | Description |
+|--------|-------------|
+| `NewManager(relayFile string) *Manager` | Create manager with relay config path |
+| `ListRelays() ([]ServeRelay, error)` | Return all stored relays |
+| `GetRelay(id string) (*ServeRelay, error)` | Get relay by ID |
+| `UpsertRelay(relay ServeRelay) error` | Create/update relay and reconcile |
+| `DeleteRelay(id string) error` | Remove relay and reconcile |
+| `ToggleRelay(id string, enabled bool) error` | Enable/disable relay and reconcile |
+| `Reconcile() error` | Reset serve config and reapply all enabled relays |
+| `Status() (*ServeStatusJSON, error)` | Parse `tailscale serve status --json` |
+
+### `ErrTailscaleNotReady`
+
+```go
+var ErrTailscaleNotReady = fmt.Errorf("tailscale not ready")
+```
+
+Returned by `Reconcile()` (and transitively by `UpsertRelay`, `DeleteRelay`,
+`ToggleRelay`) when Tailscale is not yet authenticated or connected.
+
+**Callers must use `errors.Is` to distinguish this from real failures:**
+
+```go
+if err := manager.UpsertRelay(relay); err != nil {
+    if errors.Is(err, serve.ErrTailscaleNotReady) {
+        // relay config saved; return 202 Accepted so UI shows pending state
+        w.WriteHeader(http.StatusAccepted)
+        return
+    }
+    http.Error(w, err.Error(), http.StatusInternalServerError)
+    return
+}
+```
+
+Relay config is persisted before `Reconcile()` is called, so a deferred
+reconcile does not lose data — it is applied on the next successful reconcile
+(e.g. after Tailscale authenticates or `IsTailscaleReady()` returns true).
+
+### Reconciliation Flow
+
+1. Load `serve_relays.json`
+2. `tailscale serve reset` — clears all serve rules
+3. For each enabled relay, run:
+   - HTTPS: `tailscale serve https:<port> http://<host>:<port>`
+   - TCP:   `tailscale serve tcp:<port> tcp://<host>:<port>`
+4. If step 2 returns a not-ready error → return `ErrTailscaleNotReady`
+
+Startup reconcile is driven by `server.go` in a background goroutine that
+polls `IsTailscaleReady()` every 2 s (up to 15 attempts).
+
+## HTTP Handlers (`webui/internal/handlers/serve.go`)
+
+### Endpoint Map
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET`  | `/api/serve/https/list`     | Yes | List HTTPS relays with `running` status |
+| `GET`  | `/api/serve/https/get`      | Yes | Get single HTTPS relay (`?id=`) |
+| `POST` | `/api/serve/https/create`   | Yes | Create HTTPS relay (JSON or multipart) |
+| `POST` | `/api/serve/https/update`   | Yes | Update HTTPS relay (`id` required) |
+| `POST` | `/api/serve/https/delete`   | Yes | Delete HTTPS relay (`?id=`) |
+| `POST` | `/api/serve/https/toggle`   | Yes | Enable/disable HTTPS relay |
+| `GET`  | `/api/serve/tcp/list`       | Yes | List TCP relays with `running` status |
+| `GET`  | `/api/serve/tcp/get`        | Yes | Get single TCP relay (`?id=`) |
+| `POST` | `/api/serve/tcp/create`     | Yes | Create TCP relay (JSON) |
+| `POST` | `/api/serve/tcp/update`     | Yes | Update TCP relay (`id` required) |
+| `POST` | `/api/serve/tcp/delete`     | Yes | Delete TCP relay (`?id=`) |
+| `POST` | `/api/serve/tcp/toggle`     | Yes | Enable/disable TCP relay |
+| `POST` | `/api/serve/reload`         | Yes | Trigger full reconcile |
+
+### Response Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Operation applied to tailscale serve |
+| `202 Accepted` | Config saved; Tailscale not yet ready — will apply on next reconcile |
+| `400 Bad Request` | Missing/invalid fields |
+| `404 Not Found` | Relay ID not found (delete/toggle) |
+| `500 Internal Server Error` | Unexpected error |
+
+### Legacy Shims
+
+`/api/caddy/*` and `/api/socat/*` return **410 Gone** with a message
+pointing to the new `/api/serve/https/*` and `/api/serve/tcp/*` routes.
+These shims are registered before protected routes and do not require auth.
+
+### `writeServeResult` Helper
+
+All mutating handlers use the `writeServeResult(w, err, msg)` helper which
+maps `nil` → 200, `ErrTailscaleNotReady` → 202, and other errors → 500.
+
+## Migration from Legacy Configs
+
+On first startup with a legacy config, the following migrations are applied
+automatically by `config.MigrateLegacyRelaysToServe`:
+
+| Source file | Target |
+|-------------|--------|
+| `relays.json` (socat) | `serve_relays.json` with `type: tcp` |
+| `proxies.json` (caddy) | `serve_relays.json` with `type: https` |
+| `RELAY_LIST` env var | `serve_relays.json` with `type: tcp` |
+
+## Running Status Detection
+
+TCP/HTTPS relay running state is determined by matching `relay.ListenPort`
+against the port keys in `tailscale serve status --json` → `.TCP`.
+- TCP relay is `running` if `TCP[port].HTTPS == false`
+- HTTPS relay is `running` if `TCP[port].HTTPS == true`
+
+**Limitation:** this matching is port-based and can be unreliable if ports
+are reused or serve config is edited outside the UI.
+
+## Testing
+
+Go unit tests: `webui/internal/serve/manager_test.go`
+
+Integration tests covering serve relay behaviour:
+- `TestServeRelays.test_tcp_relay_create_and_list`
+- `TestServeRelays.test_tcp_relay_delete_removes_from_list`
+- `TestLegacyEndpointShims.test_caddy_endpoint_returns_410`
+- `TestLegacyEndpointShims.test_socat_endpoint_returns_410`

--- a/.agents/skills/testing-cicd/SKILL.md
+++ b/.agents/skills/testing-cicd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing-cicd
 description: Writing tests and CI/CD for tailrelay — Go unit tests, Python integration tests, CI pipeline jobs, and test infrastructure. Use when adding new tests, extending the integration suite, modifying ci.yml, or improving test coverage for any Go package or the container behaviour.
-reviewed_at: b7ce114
+reviewed_at: f7df402
 ---
 
 # Tests & CI/CD
@@ -27,17 +27,10 @@ webui/
 │   │   └── middleware_test.go          ✓ exists
 │   ├── backup/
 │   │   └── backup_test.go              ✓ exists
-│   ├── caddy/
-│   │   ├── manager_test.go             ✓ exists
-│   │   ├── metrics_parser_test.go      ✓ exists
-│   │   ├── metrics_store_test.go       ✓ exists
-│   │   └── proxy_manager_test.go       ✓ exists
 │   ├── handlers/
 │   │   ├── auth_test.go                ✓ exists
-│   │   ├── backup_test.go              ✓ exists
-│   │   ├── caddy_test.go               ✓ exists
-│   │   └── socat_test.go               ✓ exists
-│   ├── socat/                          ✗ no tests yet
+│   │   └── backup_test.go              ✓ exists
+│   ├── serve/                          ✗ no tests yet
 │   ├── tailscale/                      ✗ no tests yet
 │   └── web/
 │       └── server_test.go              ✓ exists
@@ -47,11 +40,11 @@ tests/
     ├── __init__.py
     ├── conftest.py                     session-scoped Docker fixtures
     ├── helpers.py                      subprocess + container_exec utilities
-    └── test_integration.py             pytest test classes (332 lines)
+    └── test_integration.py             pytest test classes
 ```
 
 **Packages without tests** — prioritise these when adding coverage:
-- `webui/internal/socat/` — relay lifecycle, start/stop, config parsing
+- `webui/internal/serve/` — relay lifecycle, reconcile, ErrTailscaleNotReady
 - `webui/internal/tailscale/` — status parsing, cache behaviour, client mocking
 - `webui/internal/config/` — YAML parsing edge cases
 - `webui/internal/handlers/dashboard.go`, `tailscale.go` — handler coverage
@@ -176,23 +169,23 @@ func TestParseRelays(t *testing.T) {
 
 ### Mocking External Services
 
-For packages that call external processes (Caddy Admin API, `tailscale` CLI, `socat`), use interface mocking:
+For packages that call external processes (`tailscale` CLI), use interface mocking:
 
 ```go
 // Define interface in production code
-type CaddyClient interface {
-    AddRoute(route CaddyRoute) error
-    DeleteRoute(id string) error
+type ServeManager interface {
+    UpsertRelay(relay config.ServeRelay) error
+    DeleteRelay(id string) error
 }
 
 // Use a fake in tests
-type fakeCaddyClient struct {
-    routes map[string]CaddyRoute
+type fakeServeManager struct {
+    relays map[string]config.ServeRelay
 }
-func (f *fakeCaddyClient) AddRoute(r CaddyRoute) error { ... }
+func (f *fakeServeManager) UpsertRelay(r config.ServeRelay) error { ... }
 ```
 
-Existing patterns to follow: `webui/internal/caddy/manager_test.go`, `webui/internal/handlers/caddy_test.go`.
+Existing patterns to follow: `webui/internal/handlers/auth_test.go`, `webui/internal/handlers/backup_test.go`.
 
 ---
 
@@ -256,7 +249,6 @@ Examples:
 | Web UI | `http://127.0.0.1:8021` |
 | Tailscale health | `http://127.0.0.1:9002/healthz` |
 | Tailscale metrics | `http://127.0.0.1:9002/metrics` |
-| Caddy Admin API | `http://127.0.0.1:2019` |
 
 ### Environment Variables for Integration Tests
 
@@ -348,10 +340,9 @@ Example security job:
 |---------|---------|----------|
 | `internal/auth` | ✓ `middleware_test.go` | Maintain |
 | `internal/backup` | ✓ `backup_test.go` | Maintain |
-| `internal/caddy` | ✓ `manager_test.go`, `proxy_manager_test.go`, `metrics_parser_test.go`, `metrics_store_test.go` | Maintain |
-| `internal/handlers` | ✓ auth, backup, caddy, socat | Add: dashboard, tailscale handlers |
+| `internal/handlers` | ✓ auth, backup | Add: serve, dashboard, tailscale handlers |
 | `internal/web` | ✓ `server_test.go` | Maintain |
-| `internal/socat` | ✗ none | **High** |
+| `internal/serve` | ✗ none | **High** |
 | `internal/tailscale` | ✗ none | **High** |
 | `internal/config` | ✗ none | Medium |
 | `internal/logger` | ✗ none | Low |

--- a/.agents/skills/testing-cicd/SKILL.md
+++ b/.agents/skills/testing-cicd/SKILL.md
@@ -238,8 +238,8 @@ test_<subsystem>_<what>_<expected_outcome>
 
 Examples:
   test_webui_health_returns_200
-  test_caddy_proxy_add_persists_after_restart
-  test_socat_relay_invalid_port_rejected
+  test_serve_tcp_relay_add_persists_after_restart
+  test_serve_relay_invalid_port_rejected
 ```
 
 ### Addresses Inside the Container

--- a/.agents/skills/webui/SKILL.md
+++ b/.agents/skills/webui/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: webui-development
 description: Go Web UI application development — handlers, authentication, backup, frontend SPA, build workflow, and testing. Use when working with the webui/ directory, Go code, frontend assets, HTML templates, the SPA build system, or any Web UI feature development.
-reviewed_at: b7ce114
+reviewed_at: f7df402
 ---
 
 # Web UI Development
 
 ## Overview
 
-The Web UI is a Go application serving a single-page application (SPA) on port 8021. It manages Tailscale, Caddy proxies, socat relays, and backups through a browser interface.
+The Web UI is a Go application serving a single-page application (SPA) on port 8021. It manages Tailscale, `tailscale serve` relays, and backups through a browser interface.
 
 ## Project Structure
 
@@ -21,14 +21,11 @@ webui/
 ├── internal/
 │   ├── auth/               # Authentication middleware
 │   ├── backup/             # Backup & restore (tar.gz)
-│   ├── caddy/              # Caddy API integration (see caddy skill)
-│   │   ├── manager.go          # Proxy/metrics lifecycle, StartMetricsPoller, FlushMetrics
-│   │   ├── metrics_store.go    # MetricsStore — ring buffer snapshots, Query, RecordPause, Flush
-│   │   └── metrics_parser.go   # Prometheus scrape parser, server-keyed HostMetrics
 │   ├── config/             # YAML config parsing
 │   ├── handlers/           # HTTP request handlers
 │   ├── logger/             # Structured logging
-│   ├── socat/              # Socat process management (see socat skill)
+│   ├── serve/              # tailscale serve relay management (see serve-relay-management skill)
+│   │   └── manager.go      # Manager: Reconcile, UpsertRelay, DeleteRelay, ToggleRelay
 │   ├── tailscale/          # Tailscale CLI wrapper (see tailscale skill)
 │   │   ├── client.go       # CLI wrapper (status, login, etc.)
 │   │   ├── status.go       # Status parsing structs
@@ -40,16 +37,10 @@ webui/
 │   │   ├── main.js         # SPA entry point
 │   │   └── lib/
 │   │       ├── components/
-│   │       │   ├── Metrics.svelte      # Traffic metrics panel (window selector, relay filter, reset, truncateTarget)
-│   │       │   ├── AddModal.svelte     # Add proxy modal (tlsMode three-segment control, Advanced collapsible section)
-│   │       │   └── Tooltip.svelte      # Portal-based tooltip (p-2/-m-2 tap target, gap bridge, document-level dismiss)
+│   │       │   ├── AddModal.svelte     # Add relay modal
+│   │       │   └── Tooltip.svelte      # Portal-based tooltip
 │   │       └── stores/
-│   │           └── metrics.js          # metricsWindow, metricsResetting stores; fetchMetrics(window), resetMetrics
-│   ├── vite.config.js
-│   ├── svelte.config.js
-│   └── package.json        # Build config (Vite, Svelte, Tailwind)
 ├── config/                 # Example webui.yaml
-├── examples/               # Usage examples (caddy_api_example.go)
 ├── go.mod / go.sum
 └── README.md
 ```
@@ -103,10 +94,17 @@ Access: `./tailrelay-webui --version`
 
 ## Internal Packages
 
+### `serve/` — Tailscale Serve Relay Manager
+
+- **`manager.go`**: Manages `tailscale serve` relays via the Tailscale CLI
+  - `ErrTailscaleNotReady` — exported sentinel; returned by `Reconcile()` and mutating ops when Tailscale is not yet connected
+  - `Reconcile()` — applies `serve_relays.json` state to running `tailscale serve` config; returns `ErrTailscaleNotReady` if Tailscale not up yet
+  - `UpsertRelay`, `DeleteRelay`, `ToggleRelay` — CRUD ops; callers check `errors.Is(err, serve.ErrTailscaleNotReady)`
+
 ### `tailscale/` — Tailscale CLI Wrapper
 
 - **`client.go`**: Wraps CLI commands (`tailscale status --json`, `tailscale up`, etc.)
-- **`status.go`**: Go structs for parsing status JSON
+- **`status.go`**: Go structs for parsing status JSON; peers sorted with `sort.Slice`
 - **`cache.go`**: `StatusCache` — background goroutine polls `IsConnected` every 15 seconds; provides a non-blocking `IsReady()` check used by TLS cert probes and auth middleware. Starts via `StatusCache.Start(ctx)`.
 
 ### `auth/` — Authentication Middleware
@@ -133,18 +131,24 @@ auth:
 paths:
   config_dir: /var/lib/tailscale
   token_file: /var/lib/tailscale/.webui_token
-  relays_file: /var/lib/tailscale/relays.json
+  serve_relay_config: /var/lib/tailscale/serve_relays.json
   backup_dir: /var/lib/tailscale/backups
 ```
 
 ### `handlers/` — HTTP Handlers
 
 Route handlers for all API endpoints:
-- `caddy.go` — Proxy CRUD
-- `socat.go` — Relay management
+- `serve.go` — Relay CRUD (`/api/serve/*`); uses `writeServeResult` helper for 200/202/500 responses
 - `tailscale.go` — Status, login
 - `backup.go` — Backup operations
 - `dashboard.go` — System overview
+
+**`writeServeResult` helper** (in `handlers/serve.go`): maps manager errors to HTTP status codes:
+- `nil` → 200 OK
+- `serve.ErrTailscaleNotReady` → 202 Accepted
+- other error → 500 Internal Server Error
+
+Legacy `/api/caddy/` and `/api/socat/` paths return **410 Gone** (registered without auth middleware in `web/server.go`).
 
 ### `web/` — HTTP Server
 
@@ -163,9 +167,6 @@ Built with **Vite + Svelte 5 + Tailwind CSS 4** via npm:
 - Entry: `frontend/src/main.js`
 - Output: `cmd/webui/web/dist/` (embedded via `//go:embed`)
 - Icons: Lucide Svelte (`@lucide/svelte`) — imported directly as Svelte components
-- Charts: Chart.js (`chart.js`)
-- `AddModal.svelte` exposes an **Advanced** collapsible section containing Trusted Proxies and a Host Header input field (`hostHeader` state maps to `CaddyProxy.HostHeader`)
-- `Metrics.svelte` truncates relay target hostnames >30 chars to `<first 12>…<last 12>:<port>` via `truncateTarget`; full target shown via native `title` tooltip
 
 > **Note:** Bootstrap Icons and the SVG sprite are no longer used. Icons are now Lucide Svelte components imported directly.
 
@@ -178,9 +179,8 @@ Built with **Vite + Svelte 5 + Tailwind CSS 4** via npm:
 | `auth.enable_token_auth` | `true` | Token-based authentication |
 | `paths.config_dir` | `/var/lib/tailscale` | Config directory |
 | `paths.token_file` | `.webui_token` | Auth token file |
-| `paths.relays_file` | `relays.json` | Socat relay config |
+| `paths.serve_relay_config` | `serve_relays.json` | tailscale serve relay config |
 | `paths.backup_dir` | `backups/` | Backup storage |
-| `paths.metrics_history_file` | `metrics_history.json` | Persisted metrics ring buffer |
 
 ## Testing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     types: [published]
 
 env:
+  # Suppress Node.js deprecation warnings from GitHub Actions runner internals
+  # that use an older Node.js version than 24 (actions/checkout, etc.).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -269,3 +269,92 @@ class TestTCPRelay:
         data = parse_json_body(body, "/api/serve/tcp/list")
         ids = [item.get("relay", {}).get("id") for item in data]
         assert self.RELAY_ID in ids, f"Created relay {self.RELAY_ID} not found in API list"
+
+    def test_tcp_relay_delete_removes_from_list(self, running_container: str) -> None:
+        """Create a relay, delete it, and verify it no longer appears in the list."""
+        token = get_webui_token(running_container)
+
+        # Ensure the relay exists first.
+        payload = self._create_relay_payload()
+        container_exec(
+            running_container,
+            f"wget -qO- --timeout=10 --tries=1 "
+            f'--header="Authorization: Bearer {token}" '
+            f'--header="Content-Type: application/json" '
+            f"--post-data='{payload}' "
+            f"{WEBUI_ADDR}/api/serve/tcp/create",
+        )
+        time.sleep(1)
+
+        # Delete the relay.
+        delete_result = container_exec(
+            running_container,
+            f"wget -qO- --timeout=10 --tries=1 "
+            f'--header="Authorization: Bearer {token}" '
+            f"--post-data='' "
+            f'"{WEBUI_ADDR}/api/serve/tcp/delete?id={self.RELAY_ID}"',
+        )
+        assert delete_result.returncode == 0, (
+            f"DELETE /api/serve/tcp/delete failed (exit {delete_result.returncode}):\n"
+            f"stdout: {delete_result.stdout}\nstderr: {delete_result.stderr}"
+        )
+
+        # Verify relay no longer appears in API list.
+        body = wget_authed_ok(
+            running_container, f"{WEBUI_ADDR}/api/serve/tcp/list", token
+        )
+        data = parse_json_body(body, "/api/serve/tcp/list")
+        ids = [item.get("relay", {}).get("id") for item in data]
+        assert self.RELAY_ID not in ids, (
+            f"Deleted relay {self.RELAY_ID} still appears in API list"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Legacy endpoint shims
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyEndpointShims:
+    """Removed /api/caddy/* and /api/socat/* endpoints return 410 Gone."""
+
+    def _wget_status(self, container: str, url: str, token: str) -> int:
+        """Return the HTTP status code from wget's server-response header."""
+        result = container_exec(
+            container,
+            f"wget -S --spider --timeout=5 --tries=1 "
+            f'--header="Authorization: Bearer {token}" '
+            f"{url} 2>&1",
+        )
+        output = result.stdout + result.stderr
+        for line in output.splitlines():
+            line = line.strip()
+            if line.startswith("HTTP/") and len(line.split()) >= 2:
+                try:
+                    return int(line.split()[1])
+                except ValueError:
+                    pass
+        return -1
+
+    def test_caddy_endpoint_returns_410(self, running_container: str) -> None:
+        token = get_webui_token(running_container)
+        status = self._wget_status(
+            running_container,
+            f"{WEBUI_ADDR}/api/caddy/list",
+            token,
+        )
+        assert status == 410, (
+            f"Expected 410 Gone from /api/caddy/list, got {status}"
+        )
+
+    def test_socat_endpoint_returns_410(self, running_container: str) -> None:
+        token = get_webui_token(running_container)
+        status = self._wget_status(
+            running_container,
+            f"{WEBUI_ADDR}/api/socat/list",
+            token,
+        )
+        assert status == 410, (
+            f"Expected 410 Gone from /api/socat/list, got {status}"
+        )
+

--- a/webui/internal/handlers/serve.go
+++ b/webui/internal/handlers/serve.go
@@ -52,7 +52,8 @@ func (h *ServeHandler) IsTailscaleReady() bool {
 
 // writeServeResult encodes a JSON success response.  If err is
 // ErrTailscaleNotReady it writes 202 Accepted so the UI can show a "pending"
-// state instead of an error.  Any other error produces 500.
+// state instead of an error.  ErrRelayNotFound produces 404.  Any other error
+// produces 500.
 func writeServeResult(w http.ResponseWriter, err error, msg string) {
 	if err == nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -67,6 +68,10 @@ func writeServeResult(w http.ResponseWriter, err error, msg string) {
 			"status":  "pending",
 			"message": msg + " (tailscale not yet ready — relay config saved and will be applied when connected)",
 		})
+		return
+	}
+	if errors.Is(err, serve.ErrRelayNotFound) {
+		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -183,10 +188,6 @@ func (h *ServeHandler) DeleteTCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	err := h.manager.DeleteRelay(id)
-	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
 	writeServeResult(w, err, "Relay deleted successfully")
 }
 
@@ -209,10 +210,6 @@ func (h *ServeHandler) ToggleTCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	err := h.manager.ToggleRelay(req.ID, req.Enabled)
-	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
 	writeServeResult(w, err, "Relay toggled successfully")
 }
 
@@ -327,10 +324,6 @@ func (h *ServeHandler) DeleteHTTPS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	err := h.manager.DeleteRelay(id)
-	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
 	writeServeResult(w, err, "Proxy deleted successfully")
 }
 
@@ -353,10 +346,6 @@ func (h *ServeHandler) ToggleHTTPS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	err := h.manager.ToggleRelay(req.ID, req.Enabled)
-	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
 	writeServeResult(w, err, "Proxy toggled successfully")
 }
 

--- a/webui/internal/handlers/serve.go
+++ b/webui/internal/handlers/serve.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -48,6 +50,28 @@ func (h *ServeHandler) IsTailscaleReady() bool {
 	return connected
 }
 
+// writeServeResult encodes a JSON success response.  If err is
+// ErrTailscaleNotReady it writes 202 Accepted so the UI can show a "pending"
+// state instead of an error.  Any other error produces 500.
+func writeServeResult(w http.ResponseWriter, err error, msg string) {
+	if err == nil {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": msg})
+		return
+	}
+	if errors.Is(err, serve.ErrTailscaleNotReady) {
+		log.Printf("serve: tailscale not ready, returning 202 Accepted")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status":  "pending",
+			"message": msg + " (tailscale not yet ready — relay config saved and will be applied when connected)",
+		})
+		return
+	}
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
 // ── TCP relay handlers (/api/serve/tcp/*) ─────────────────────────────────────
 
 // APIListTCP returns all TCP relays as JSON.
@@ -58,7 +82,10 @@ func (h *ServeHandler) APIListTCP(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	statusJSON, _ := h.manager.Status()
+	statusJSON, statusErr := h.manager.Status()
+	if statusErr != nil {
+		log.Printf("serve: status check failed, running state may be inaccurate: %v", statusErr)
+	}
 
 	type relayStatus struct {
 		Relay   config.ServeRelay `json:"relay"`
@@ -122,12 +149,7 @@ func (h *ServeHandler) CreateTCP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "listen_port, target_host, and target_port are required", http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.UpsertRelay(relay); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Relay created successfully"})
+	writeServeResult(w, h.manager.UpsertRelay(relay), "Relay created successfully")
 }
 
 // UpdateTCP updates a TCP relay.
@@ -146,12 +168,7 @@ func (h *ServeHandler) UpdateTCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	relay.Type = "tcp"
-	if err := h.manager.UpsertRelay(relay); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Relay updated successfully"})
+	writeServeResult(w, h.manager.UpsertRelay(relay), "Relay updated successfully")
 }
 
 // DeleteTCP deletes a TCP relay.
@@ -165,12 +182,12 @@ func (h *ServeHandler) DeleteTCP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Relay ID is required", http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.DeleteRelay(id); err != nil {
+	err := h.manager.DeleteRelay(id)
+	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Relay deleted successfully"})
+	writeServeResult(w, err, "Relay deleted successfully")
 }
 
 // ToggleTCP enables/disables a TCP relay.
@@ -191,12 +208,12 @@ func (h *ServeHandler) ToggleTCP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Relay ID is required", http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.ToggleRelay(req.ID, req.Enabled); err != nil {
+	err := h.manager.ToggleRelay(req.ID, req.Enabled)
+	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Relay toggled successfully"})
+	writeServeResult(w, err, "Relay toggled successfully")
 }
 
 // ── HTTPS relay handlers (/api/serve/https/*) ─────────────────────────────────
@@ -214,7 +231,10 @@ func (h *ServeHandler) APIListHTTPS(w http.ResponseWriter, _ *http.Request) {
 		hostname = status.MagicDNSName
 	}
 
-	statusJSON, _ := h.manager.Status()
+	statusJSON, statusErr := h.manager.Status()
+	if statusErr != nil {
+		log.Printf("serve: status check failed, running state may be inaccurate: %v", statusErr)
+	}
 
 	type relayStatus struct {
 		config.ServeRelay
@@ -273,12 +293,7 @@ func (h *ServeHandler) CreateHTTPS(w http.ResponseWriter, r *http.Request) {
 	if relay.ID == "" {
 		relay.ID = fmt.Sprintf("https-%d", relay.ListenPort)
 	}
-	if err := h.manager.UpsertRelay(relay); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Proxy created successfully"})
+	writeServeResult(w, h.manager.UpsertRelay(relay), "Proxy created successfully")
 }
 
 // UpdateHTTPS updates an HTTPS relay.
@@ -297,12 +312,7 @@ func (h *ServeHandler) UpdateHTTPS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	relay.Type = "https"
-	if err := h.manager.UpsertRelay(relay); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Proxy updated successfully"})
+	writeServeResult(w, h.manager.UpsertRelay(relay), "Proxy updated successfully")
 }
 
 // DeleteHTTPS deletes an HTTPS relay.
@@ -316,12 +326,12 @@ func (h *ServeHandler) DeleteHTTPS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Proxy ID is required", http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.DeleteRelay(id); err != nil {
+	err := h.manager.DeleteRelay(id)
+	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Proxy deleted successfully"})
+	writeServeResult(w, err, "Proxy deleted successfully")
 }
 
 // ToggleHTTPS enables/disables an HTTPS relay.
@@ -342,25 +352,17 @@ func (h *ServeHandler) ToggleHTTPS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Proxy ID is required", http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.ToggleRelay(req.ID, req.Enabled); err != nil {
+	err := h.manager.ToggleRelay(req.ID, req.Enabled)
+	if err != nil && !errors.Is(err, serve.ErrTailscaleNotReady) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Proxy toggled successfully"})
+	writeServeResult(w, err, "Proxy toggled successfully")
 }
 
 // ReloadServe reconciles all enabled relays.
 func (h *ServeHandler) ReloadServe(w http.ResponseWriter, r *http.Request) {
-	if err := h.manager.Reconcile(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"status":  "success",
-		"message": "tailscale serve configuration is up to date",
-	})
+	writeServeResult(w, h.manager.Reconcile(), "tailscale serve configuration is up to date")
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/webui/internal/serve/manager.go
+++ b/webui/internal/serve/manager.go
@@ -143,7 +143,7 @@ func (m *Manager) DeleteRelay(id string) error {
 		filtered = append(filtered, r)
 	}
 	if !found {
-		return fmt.Errorf("relay not found")
+		return ErrRelayNotFound
 	}
 	list.Relays = filtered
 	if err := config.SaveServeRelays(m.relayFile, list); err != nil {
@@ -167,7 +167,7 @@ func (m *Manager) ToggleRelay(id string, enabled bool) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("relay not found")
+		return ErrRelayNotFound
 	}
 	if err := config.SaveServeRelays(m.relayFile, list); err != nil {
 		return err
@@ -179,6 +179,10 @@ func (m *Manager) ToggleRelay(id string, enabled bool) error {
 // authenticated or connected. Callers can use errors.Is to distinguish a
 // deferred reconcile from a real failure.
 var ErrTailscaleNotReady = fmt.Errorf("tailscale not ready")
+
+// ErrRelayNotFound is returned by DeleteRelay and ToggleRelay when no relay
+// with the given ID exists in the config file.
+var ErrRelayNotFound = fmt.Errorf("relay not found")
 
 // isTailscaleNotReady reports whether err indicates Tailscale is not yet
 // authenticated or connected (e.g. during container startup in CI).

--- a/webui/internal/serve/manager.go
+++ b/webui/internal/serve/manager.go
@@ -175,6 +175,11 @@ func (m *Manager) ToggleRelay(id string, enabled bool) error {
 	return m.Reconcile()
 }
 
+// ErrTailscaleNotReady is returned by Reconcile when Tailscale is not yet
+// authenticated or connected. Callers can use errors.Is to distinguish a
+// deferred reconcile from a real failure.
+var ErrTailscaleNotReady = fmt.Errorf("tailscale not ready")
+
 // isTailscaleNotReady reports whether err indicates Tailscale is not yet
 // authenticated or connected (e.g. during container startup in CI).
 func isTailscaleNotReady(err error) bool {
@@ -203,8 +208,8 @@ func (m *Manager) Reconcile() error {
 	logger.Debug("serve", "Resetting tailscale serve config")
 	if err := m.run("serve", "reset"); err != nil {
 		if isTailscaleNotReady(err) {
-			logger.Debug("serve", "Tailscale not ready, skipping reconcile: %v", err)
-			return nil
+			logger.Debug("serve", "Tailscale not ready, deferring reconcile: %v", err)
+			return ErrTailscaleNotReady
 		}
 		logger.Error("serve", "tailscale serve reset failed: %v", err)
 		return err

--- a/webui/internal/tailscale/status.go
+++ b/webui/internal/tailscale/status.go
@@ -2,6 +2,7 @@ package tailscale
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -161,20 +162,13 @@ func (c *Client) GetPeers() ([]PeerInfo, error) {
 		peers = append(peers, info)
 	}
 
-	// Sort: Exit nodes first, then by Hostname
-	import_sort := true
-	_ = import_sort
-	for i := 0; i < len(peers); i++ {
-		for j := i + 1; j < len(peers); j++ {
-			if peers[j].ExitNode && !peers[i].ExitNode {
-				peers[i], peers[j] = peers[j], peers[i]
-			} else if peers[i].ExitNode == peers[j].ExitNode {
-				if strings.ToLower(peers[i].Hostname) > strings.ToLower(peers[j].Hostname) {
-					peers[i], peers[j] = peers[j], peers[i]
-				}
-			}
+	// Sort: exit nodes first, then alphabetically by hostname.
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].ExitNode != peers[j].ExitNode {
+			return peers[i].ExitNode
 		}
-	}
+		return strings.ToLower(peers[i].Hostname) < strings.ToLower(peers[j].Hostname)
+	})
 
 	return peers, nil
 }

--- a/webui/internal/web/server.go
+++ b/webui/internal/web/server.go
@@ -214,6 +214,18 @@ func (s *Server) setupRoutes() *http.ServeMux {
 		mux.Handle("/static/", http.StripPrefix("/static/", s.staticFileHandler(fileServer)))
 	}
 
+	// Legacy endpoint shims — removed endpoints return 410 Gone with migration hint.
+	// These are registered before the protected catch-all so they respond without auth.
+	legacyGone := func(newBase string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte("This endpoint has been removed. Use " + newBase + " instead.\n"))
+		}
+	}
+	mux.HandleFunc("/api/caddy/", legacyGone("/api/serve/https/"))
+	mux.HandleFunc("/api/socat/", legacyGone("/api/serve/tcp/"))
+
 	// Protected routes (authentication required)
 	mux.Handle("/", s.authMW.RequireAuth(http.HandlerFunc(s.handleSPAFallback)))
 	mux.Handle("/api/auth/logout", s.authMW.RequireAuth(http.HandlerFunc(s.authH.Logout)))


### PR DESCRIPTION
## Summary

Implements all follow-up items from the Copilot review on PR #23 that were in the closed-without-merge PR #24.

## Changes

- **`ErrTailscaleNotReady` sentinel** — exported from `serve/manager.go`; `Reconcile()` returns it when Tailscale is not yet up, enabling callers to use `errors.Is`
- **`writeServeResult` helper** — centralises 200/202/500 response logic in `handlers/serve.go`; all 9 mutating handlers now use it
- **Delete/toggle handlers** — two-step error check: missing relay → 404; `ErrTailscaleNotReady` → 202
- **Silent error discard fix** — `statusJSON` marshal errors now logged via `log.Printf`
- **410 Gone shims** — `/api/caddy/` and `/api/socat/` return 410 without auth requirement
- **Bubble sort removed** — `sort.Slice` used in `tailscale/status.go`
- **CI comment** — explains `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var in `ci.yml`
- **Integration tests** — `test_tcp_relay_delete_removes_from_list`, `test_caddy_endpoint_returns_410`, `test_socat_endpoint_returns_410`
- **`serve/SKILL.md`** — new agent skill documenting serve relay management
- **Stale skill files updated** — caddy/socat references removed from webui, docker-ci, tailscale, testing-cicd, documentation skills