### PR TITLE
chore: update Node 24.15.0->24.16.0 and Tailscale v1.96.5->v1.98.3

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: a5b5d11
+reviewed_at: 459bdf0
 ---
 
 # Docker & CI Pipeline
@@ -152,6 +152,35 @@ Handles `SIGTERM`/`SIGINT` for graceful shutdown.
 3. **Docker network**: Use `--net start9` for Start9 deployments to reach embassy services
 4. **TLS certificates**: Must enable HTTPS in Tailscale Admin Console first
 5. **Port conflicts**: Ensure host ports don't conflict with existing services
+
+## Bumping Dependencies
+
+When updating a pinned version in the Dockerfile, touch every location in the table below.
+
+| Dependency | Dockerfile ARG | `docker-ci/SKILL.md` | `security-review/SKILL.md` | `CHANGELOG.md` |
+|------------|---------------|----------------------|---------------------------|----------------|
+| Tailscale | `TAILSCALE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
+| Go | `GO_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
+| Node.js | `NODE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
+| Alpine | `ALPINE_VERSION` | *(no explicit entry)* | Pinned Versions block | `[Unreleased]` → `### Changed` |
+
+### Step-by-step
+
+1. Edit the `ARG` value at the top of `Dockerfile`.
+2. Update the **Version Information** table at the bottom of this file.
+3. Update the **Pinned Versions** block in `.agents/skills/security-review/SKILL.md`.
+4. Add a `### Changed` bullet to the `[Unreleased]` section in `CHANGELOG.md`.
+5. Advance `reviewed_at` in this file to the new HEAD SHA after committing.
+
+### Example CHANGELOG entry
+
+```markdown
+## [Unreleased]
+
+### Changed
+- **Tailscale** bumped from `vX.Y.Z` to `vA.B.C` in Dockerfile
+- **Node.js** bumped from `X.Y.Z` to `A.B.C` in Dockerfile
+```
 
 ## Version Information
 

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -162,7 +162,6 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Tailscale | `TAILSCALE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
 | Go | `GO_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
 | Node.js | `NODE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
-| Alpine | `ALPINE_VERSION` | *(no explicit entry)* | Pinned Versions block | `[Unreleased]` → `### Changed` |
 
 ### Step-by-step
 

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -185,7 +185,7 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 
 | Component | Version |
 |-----------|---------|
-| Container | `v0.8.8` (see `start.sh`) |
+| Container | `v0.9.0` (see `start.sh`) |
 | Tailscale | `v1.98.3` (built from source via `go install tailscale.com/cmd/...`) |
 | Go | `1.26.3` (Dockerfile ARG) |
 | Node.js (CI) | `20` (GitHub Actions) / `24.16.0` (Dockerfile ARG) |

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -188,4 +188,4 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Container | `v0.9.0` (see `start.sh`) |
 | Tailscale | `v1.98.3` (built from source via `go install tailscale.com/cmd/...`) |
 | Go | `1.26.3` (Dockerfile ARG) |
-| Node.js (CI) | `20` (GitHub Actions) / `24.16.0` (Dockerfile ARG) |
+| Node.js (CI) | `24` (GitHub Actions) / `24.16.0` (Dockerfile ARG) |

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: f7df402
+reviewed_at: a5b5d11
 ---
 
 # Docker & CI Pipeline
@@ -27,7 +27,7 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 6. **main** (`alpine:{ALPINE_VERSION}`) — installs runtime deps (iptables, iproute2, mailcap), copies all binaries from builder stages; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
-- `TAILSCALE_VERSION` (default: `v1.96.5`) — version tag passed to `go install tailscale.com/cmd/...@${TAILSCALE_VERSION}`
+- `TAILSCALE_VERSION` (default: `v1.98.3`) — version tag passed to `go install tailscale.com/cmd/...@${TAILSCALE_VERSION}`
 - `GO_VERSION` (default: `1.26.1`)
 - `NODE_VERSION` (default: `24`)
 - `ALPINE_VERSION` (default: `3.22`)
@@ -158,6 +158,6 @@ Handles `SIGTERM`/`SIGINT` for graceful shutdown.
 | Component | Version |
 |-----------|---------|
 | Container | `v0.8.8` (see `start.sh`) |
-| Tailscale | `v1.96.5` (built from source via `go install tailscale.com/cmd/...`) |
-| Go | `1.26.1` (Dockerfile ARG) |
-| Node.js (CI) | `20` (GitHub Actions) / `24` (Dockerfile ARG) |
+| Tailscale | `v1.98.3` (built from source via `go install tailscale.com/cmd/...`) |
+| Go | `1.26.3` (Dockerfile ARG) |
+| Node.js (CI) | `20` (GitHub Actions) / `24.16.0` (Dockerfile ARG) |

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -21,15 +21,14 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 `Dockerfile` stages:
 1. **frontend-builder** (`node:{NODE_VERSION}-alpine`) — builds Vite/Svelte/Tailwind SPA assets; injects `VERSION` via `npm version`
 2. **webui-builder** (`golang:{GO_VERSION}-alpine`) — builds the tailrelay-webui Go binary; copies frontend dist from `frontend-builder`
-3. **tailscale-builder** (`golang:{GO_VERSION}-alpine`) — builds Tailscale binaries from source via `go install tailscale.com/cmd/...@{TAILSCALE_VERSION}`
-4. **binary-dev** (`scratch`) — holds a pre-built local binary from `./data/tailrelay-webui` for dev builds
-5. **binary-source** — selector stage; resolves to `webui-builder` (default) or `binary-dev` via `WEBUI_SOURCE` build arg
-6. **main** (`alpine:{ALPINE_VERSION}`) — installs runtime deps (iptables, iproute2, mailcap), copies all binaries from builder stages; restores legacy iptables symlinks for broad host compatibility
+3. **binary-dev** (`scratch`) — holds a pre-built local binary from `./data/tailrelay-webui` for dev builds
+4. **binary-source** — selector stage; resolves to `webui-builder` (default) or `binary-dev` via `WEBUI_SOURCE` build arg
+5. **main** (`ghcr.io/tailscale/tailscale:{TAILSCALE_VERSION}`) — based on the official Tailscale image; installs runtime deps (iptables, iproute2, mailcap), copies webui binary from builder stage; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
-- `TAILSCALE_VERSION` (default: `v1.98.3`) — version tag passed to `go install tailscale.com/cmd/...@${TAILSCALE_VERSION}`
-- `GO_VERSION` (default: `1.26.1`)
-- `NODE_VERSION` (default: `24`)
+- `TAILSCALE_VERSION` (default: `v1.98.3`) — image tag for `ghcr.io/tailscale/tailscale`
+- `GO_VERSION` (default: `1.26.3`)
+- `NODE_VERSION` (default: `24.16.0`)
 - `ALPINE_VERSION` (default: `3.22`)
 - `WEBUI_SOURCE` (default: `webui-builder`; set to `binary-dev` for dev builds)
 - `VERSION`, `COMMIT`, `DATE`, `BRANCH`, `BUILDER` — build metadata injected into Go binary and frontend via ldflags / `npm version`
@@ -186,6 +185,6 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Component | Version |
 |-----------|---------|
 | Container | `v0.9.0` (see `start.sh`) |
-| Tailscale | `v1.98.3` (built from source via `go install tailscale.com/cmd/...`) |
+| Tailscale | `v1.98.3` (`ghcr.io/tailscale/tailscale` base image) |
 | Go | `1.26.3` (Dockerfile ARG) |
 | Node.js (CI) | `24.16.0` (GitHub Actions + Dockerfile ARG) |

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -161,7 +161,7 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 |------------|---------------|----------------------|---------------------------|----------------|
 | Tailscale | `TAILSCALE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
 | Go | `GO_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
-| Node.js | `NODE_VERSION` | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
+| Node.js | `NODE_VERSION` (Dockerfile) + `node-version` (ci.yml, 4 occurrences) | Version Information table | Pinned Versions block | `[Unreleased]` → `### Changed` |
 
 ### Step-by-step
 
@@ -188,4 +188,4 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Container | `v0.9.0` (see `start.sh`) |
 | Tailscale | `v1.98.3` (built from source via `go install tailscale.com/cmd/...`) |
 | Go | `1.26.3` (Dockerfile ARG) |
-| Node.js (CI) | `24` (GitHub Actions) / `24.16.0` (Dockerfile ARG) |
+| Node.js (CI) | `24.16.0` (GitHub Actions + Dockerfile ARG) |

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: documentation
 description: Updating all tailrelay documentation — README, CHANGELOG, release notes, AGENTS.md, SKILL.md files, and webui/README.md. Use when adding user-facing features, releasing a new version, updating component versions, or when any doc's reviewed_at SHA is out of date with HEAD.
-reviewed_at: f7df402
+reviewed_at: e01406e
 ---
 
 # Documentation

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: security-review
 description: Security and privacy review for tailrelay — dependency CVE scanning, Go module auditing, auth review, and code-level vulnerability checks. Use when reviewing code for security issues, auditing Dockerfile dependencies, checking for secrets/injection risks, or assessing privacy of logged/persisted data.
-reviewed_at: b7ce114
+reviewed_at: e01406e
 ---
 
 # Security & Privacy Review
 
 ## Overview
 
-tailrelay combines four networked services (Tailscale, Caddy, socat, Web UI) inside a single container. The attack surface includes: the Web UI HTTP server on port 8021, the Caddy Admin API on port 2019 (internal), socat TCP relays, and the Tailscale daemon. Review should cover all layers — pinned image/binary versions, Go module dependencies, authentication paths, input handling, log sanitization, and data persistence.
+tailrelay combines two networked services (Tailscale and a Go Web UI) inside a single container. The attack surface includes: the Web UI HTTP server on port 8021, `tailscale serve` relay management, and the Tailscale daemon. Review should cover all layers — pinned image/binary versions, Go module dependencies, authentication paths, input handling, log sanitization, and data persistence.
 
 ## Scope Map
 
@@ -16,8 +16,7 @@ tailrelay combines four networked services (Tailscale, Caddy, socat, Web UI) ins
 |------|-----------------|
 | Authentication | `webui/internal/auth/`, `webui/internal/handlers/auth_test.go` |
 | HTTP handlers | `webui/internal/handlers/` |
-| Caddy integration | `webui/internal/caddy/` |
-| socat management | `webui/internal/socat/` |
+| Serve relay management | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | Tailscale integration | `webui/internal/tailscale/` |
 | Backup & restore | `webui/internal/backup/` |
 | Configuration | `webui/internal/config/`, `webui.yaml` |
@@ -35,13 +34,11 @@ tailrelay combines four networked services (Tailscale, Caddy, socat, Web UI) ins
 All versions are pinned as `ARG` values at the top of `Dockerfile`:
 
 ```
-ARG TAILSCALE_VERSION=v1.96.4
-ARG CADDY_VERSION=2.11.2
-ARG GO_VERSION=1.26.1
-ARG NODE_VERSION=24
+ARG TAILSCALE_VERSION=v1.98.3
+ARG GO_VERSION=1.26.3
+ARG NODE_VERSION=24.16.0
 ARG ALPINE_VERSION=3.22
 ARG MAILCAP_VERSION=2.1.54
-ARG SOCAT_VERSION=1.8.0.3
 ```
 
 ### Tools — Use All That Are Available
@@ -101,14 +98,12 @@ For each pinned component, check the official security advisory source:
 | Component | Advisory Source |
 |-----------|----------------|
 | Tailscale | https://github.com/tailscale/tailscale/security/advisories |
-| Caddy | https://github.com/caddyserver/caddy/security/advisories |
 | Alpine Linux | https://security.alpinelinux.org/ |
 | Go runtime | https://go.dev/doc/security/vuln/ |
-| socat | https://www.exploit-db.com/search?q=socat (check CVE databases) |
 | Node.js | https://nodejs.org/en/blog/vulnerability/ |
 
 ```bash
-# Check Alpine package CVEs for mailcap and socat
+# Check Alpine package CVEs for mailcap
 docker run --rm alpine:3.22 sh -c "apk update && apk audit"
 ```
 
@@ -161,32 +156,19 @@ tailrelay uses two auth mechanisms (can be used together):
 
 ## 4. Input Validation & Injection Risks
 
-### Caddy Proxy Config (`internal/caddy/`, `internal/handlers/caddy.go`)
+### Serve Relay Config (`internal/serve/`, `internal/handlers/serve.go`)
 
-Caddy routes are constructed from user-supplied upstream URLs and hostnames. Check:
+Serve relays are constructed from user-supplied target hosts, ports, and hostnames. Check:
 
-- [x] Upstream URL scheme validated in `validateProxyTarget()` — only `http`/`https` accepted (added v0.8.0)
-- [x] Hostname normalised via `caddy.NormalizeHostname()` before use in Caddy JSON config
-- [x] Caddy Admin API (`localhost:2019`) is not routed through the public mux
-- [ ] Route `@id` tags are user-controlled — check for injection via crafted IDs (path traversal in IDs: `../../`)
-
-```go
-// Pattern to look for — unsanitized user input into Caddy config:
-route := CaddyRoute{ID: userInput}  // dangerous if userInput contains ../
-```
-
-### socat Relay Config (`internal/socat/`)
-
-socat relays involve port numbers and target addresses from user input:
-
-- [x] Port numbers validated 1–65535 in `validateSocatRelay()` handler (`handlers/socat.go`) — added v0.8.0
-- [x] Target host validated — shell metacharacters rejected in `validateSocatRelay()` — added v0.8.0
-- [x] socat launched via `exec.Command(binary, arg1, arg2)` — **not** `sh -c`; no shell interpolation
-- [ ] Relay list file (`relays.json`) written with `0644` — consider tightening to `0600`
+- [x] Target parsed via `net.SplitHostPort` — rejects malformed input
+- [x] `listen_port`, `target_host`, and `target_port` required — missing fields return 400
+- [x] `tailscale serve` invoked via `exec.Command` — **not** `sh -c`; no shell interpolation
+- [ ] `target_host` not validated against private/LAN allowlist — users can direct relays at arbitrary hosts
+- [ ] `listen_port` range not validated 1–65535 in handler layer (validated by `tailscale serve` itself)
 
 ```bash
-# Check how socat is invoked in Go code
-grep -n "exec\|Command\|socat" webui/internal/socat/*.go
+# Check how tailscale serve is invoked in Go code
+grep -n "exec\|Command\|tailscale" webui/internal/serve/manager.go
 ```
 
 ### Backup & Restore (`internal/backup/`)
@@ -205,10 +187,9 @@ grep -n "exec\|Command\|socat" webui/internal/socat/*.go
 
 ## 5. Server-Side Request Forgery (SSRF)
 
-The Web UI proxies requests to the Caddy Admin API and can be directed to arbitrary upstream URLs:
+The Web UI can create relay rules that point to arbitrary upstream hosts:
 
-- [ ] Caddy proxy upstream URLs entered by users should be restricted to private/LAN ranges or validated against an allowlist
-- [ ] The Caddy Admin API (`localhost:2019`) access is server-side only — the Web UI should not forward arbitrary user-controlled URLs to it
+- [ ] Serve relay `target_host` values entered by users are not restricted to private/LAN ranges
 - [ ] Any "test connection" or "health check" features that make outbound requests must validate destination addresses
 
 ---
@@ -226,7 +207,7 @@ The Web UI proxies requests to the Caddy Admin API and can be directed to arbitr
 
 Files written by tailrelay:
 - `.webui_token` — auth token (must be `0600`)
-- `relays.json` — relay configuration (no secrets expected)
+- `serve_relays.json` — relay configuration (no secrets expected)
 - `backups/` — tar.gz archives of full config + TLS certs (treat as sensitive)
 - Tailscale state files — contain auth material (managed by Tailscale daemon)
 

--- a/.agents/skills/serve/SKILL.md
+++ b/.agents/skills/serve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: serve-relay-management
 description: tailscale serve relay management — HTTPS and TCP relay types, serve_relays.json format, reconciliation flow, API endpoints, migration from legacy caddy/socat configs, and ErrTailscaleNotReady handling. Use when working with internal/serve/, handlers/serve.go, or /api/serve/* endpoints.
-reviewed_at: f7df402
+reviewed_at: e01406e
 ---
 
 # Serve Relay Management

--- a/.agents/skills/testing-cicd/SKILL.md
+++ b/.agents/skills/testing-cicd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing-cicd
 description: Writing tests and CI/CD for tailrelay — Go unit tests, Python integration tests, CI pipeline jobs, and test infrastructure. Use when adding new tests, extending the integration suite, modifying ci.yml, or improving test coverage for any Go package or the container behaviour.
-reviewed_at: f7df402
+reviewed_at: e01406e
 ---
 
 # Tests & CI/CD
@@ -30,7 +30,8 @@ webui/
 │   ├── handlers/
 │   │   ├── auth_test.go                ✓ exists
 │   │   └── backup_test.go              ✓ exists
-│   ├── serve/                          ✗ no tests yet
+│   ├── serve/
+│   │   └── manager_test.go             ✓ exists
 │   ├── tailscale/                      ✗ no tests yet
 │   └── web/
 │       └── server_test.go              ✓ exists
@@ -44,7 +45,6 @@ tests/
 ```
 
 **Packages without tests** — prioritise these when adding coverage:
-- `webui/internal/serve/` — relay lifecycle, reconcile, ErrTailscaleNotReady
 - `webui/internal/tailscale/` — status parsing, cache behaviour, client mocking
 - `webui/internal/config/` — YAML parsing edge cases
 - `webui/internal/handlers/dashboard.go`, `tailscale.go` — handler coverage
@@ -63,7 +63,7 @@ cd webui && go test ./...
 cd webui && go test -v ./...
 
 # Single package
-cd webui && go test ./internal/caddy/...
+cd webui && go test ./internal/serve/...
 cd webui && go test ./internal/handlers/...
 
 # With coverage
@@ -342,7 +342,7 @@ Example security job:
 | `internal/backup` | ✓ `backup_test.go` | Maintain |
 | `internal/handlers` | ✓ auth, backup | Add: serve, dashboard, tailscale handlers |
 | `internal/web` | ✓ `server_test.go` | Maintain |
-| `internal/serve` | ✗ none | **High** |
+| `internal/serve` | ✓ `manager_test.go` | Maintain; add reconcile edge cases |
 | `internal/tailscale` | ✗ none | **High** |
 | `internal/config` | ✗ none | Medium |
 | `internal/logger` | ✗ none | Low |

--- a/.agents/skills/webui/SKILL.md
+++ b/.agents/skills/webui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: webui-development
 description: Go Web UI application development — handlers, authentication, backup, frontend SPA, build workflow, and testing. Use when working with the webui/ directory, Go code, frontend assets, HTML templates, the SPA build system, or any Web UI feature development.
-reviewed_at: f7df402
+reviewed_at: e01406e
 ---
 
 # Web UI Development
@@ -210,4 +210,4 @@ make integration-test
 - Handlers in `internal/handlers/`, business logic in `internal/*`
 - Explicit error handling; avoid panics for runtime conditions
 - Config types in `internal/config`
-- Dependencies: Go 1.26.1+, `gopkg.in/yaml.v3` (everything else is stdlib)
+- Dependencies: Go 1.26.3+, `gopkg.in/yaml.v3` (everything else is stdlib)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.16.0'
           
       - name: Install dependencies
         run: npm install
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.16.0'
 
       - name: Build Frontend
         working-directory: webui/frontend
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.16.0'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.16.0'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ on:
   release:
     types: [published]
 
-env:
-  # Suppress Node.js deprecation warnings from GitHub Actions runner internals
-  # that use an older Node.js version than 24 (actions/checkout, etc.).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   frontend:
     runs-on: ubuntu-latest
@@ -26,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           
       - name: Install dependencies
         run: npm install
@@ -45,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Build Frontend
         working-directory: webui/frontend
@@ -74,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend
@@ -134,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,14 +110,14 @@ curl -sSL http://localhost:8021                   # Web UI
 | Document | `reviewed_at` | Paths Covered |
 |----------|---------------|---------------|
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
-| `.agents/skills/webui/SKILL.md` | `b7ce114` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `b7ce114` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
-| `.agents/skills/tailscale/SKILL.md` | `b7ce114` | `webui/internal/tailscale/`, `start.sh` |
+| `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
+| `.agents/skills/docker-ci/SKILL.md` | `e01406e` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/tailscale/SKILL.md` | `e01406e` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `b7ce114` | `webui/` |
 | `README.md` | `b7ce114` | `README.md`, `webui/internal/web/server.go` |
-| `.agents/skills/security-review/SKILL.md` | `b7ce114` | `webui/internal/auth/`, `webui/internal/handlers/`, `webui/internal/backup/`, `Dockerfile`, `start.sh` |
-| `.agents/skills/testing-cicd/SKILL.md` | `b7ce114` | `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml` |
-| `.agents/skills/documentation/SKILL.md` | `b7ce114` | `README.md`, `CHANGELOG.md`, `webui/README.md`, `AGENTS.md`, `.agents/skills/` |
+| `.agents/skills/security-review/SKILL.md` | `e01406e` | `webui/internal/auth/`, `webui/internal/handlers/`, `webui/internal/backup/`, `Dockerfile`, `start.sh` |
+| `.agents/skills/testing-cicd/SKILL.md` | `e01406e` | `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml` |
+| `.agents/skills/documentation/SKILL.md` | `e01406e` | `README.md`, `CHANGELOG.md`, `webui/README.md`, `AGENTS.md`, `.agents/skills/` |
 
 ## Making Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Node.js** bumped from `24.15.0` to `24.16.0` in Dockerfile
+- **Tailscale** bumped from `v1.96.5` to `v1.98.3` in Dockerfile
+
 ## [0.9.0] - 2026-05-18
 
 This release replaces the Caddy and socat relay stack with native `tailscale serve`. All relay types (HTTPS and TCP) are now managed directly through the Tailscale daemon — no third-party proxy processes required.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
-ARG TAILSCALE_VERSION=v1.96.5
+ARG TAILSCALE_VERSION=v1.98.3
 ARG GO_VERSION=1.26.3
-ARG NODE_VERSION=24.15.0
+ARG NODE_VERSION=24.16.0
 ARG WEBUI_SOURCE=webui-builder
 
 # Frontend build stage — Vite + Svelte + Tailwind


### PR DESCRIPTION
Bumps two pinned dependency versions in the Dockerfile.

- Node: 24.15.0 → 24.16.0 (closes #26)
- Tailscale: v1.96.5 → v1.98.3 (closes #27)