### PR TITLE
chore: update Tailscale to v1.98.8 and Node to 24.18.0

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: 459bdf0
+reviewed_at: e615c2a
 ---
 
 # Docker & CI Pipeline
@@ -26,9 +26,9 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 5. **main** (`ghcr.io/tailscale/tailscale:{TAILSCALE_VERSION}`) — based on the official Tailscale image; installs runtime deps (iptables, iproute2, mailcap), copies webui binary from builder stage; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
-- `TAILSCALE_VERSION` (default: `v1.98.4`) — image tag for `ghcr.io/tailscale/tailscale`
+- `TAILSCALE_VERSION` (default: `v1.98.8`) — image tag for `ghcr.io/tailscale/tailscale`
 - `GO_VERSION` (default: `1.26.4`)
-- `NODE_VERSION` (default: `24.17.0`)
+- `NODE_VERSION` (default: `24.18.0`)
 - `ALPINE_VERSION` (default: `3.22`)
 - `WEBUI_SOURCE` (default: `webui-builder`; set to `binary-dev` for dev builds)
 - `VERSION`, `COMMIT`, `DATE`, `BRANCH`, `BUILDER` — build metadata injected into Go binary and frontend via ldflags / `npm version`
@@ -185,6 +185,6 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Component | Version |
 |-----------|---------|
 | Container | `v0.9.0` (see `start.sh`) |
-| Tailscale | `v1.98.4` (`ghcr.io/tailscale/tailscale` base image) |
+| Tailscale | `v1.98.8` (`ghcr.io/tailscale/tailscale` base image) |
 | Go | `1.26.4` (Dockerfile ARG) |
-| Node.js (CI) | `24.17.0` (GitHub Actions + Dockerfile ARG) |
+| Node.js (CI) | `24.18.0` (GitHub Actions + Dockerfile ARG) |

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-review
 description: Security and privacy review for tailrelay — dependency CVE scanning, Go module auditing, auth review, and code-level vulnerability checks. Use when reviewing code for security issues, auditing Dockerfile dependencies, checking for secrets/injection risks, or assessing privacy of logged/persisted data.
-reviewed_at: e01406e
+reviewed_at: e615c2a
 ---
 
 # Security & Privacy Review
@@ -34,9 +34,9 @@ tailrelay combines two networked services (Tailscale and a Go Web UI) inside a s
 All versions are pinned as `ARG` values at the top of `Dockerfile`:
 
 ```
-ARG TAILSCALE_VERSION=v1.98.4
+ARG TAILSCALE_VERSION=v1.98.8
 ARG GO_VERSION=1.26.4
-ARG NODE_VERSION=24.17.0
+ARG NODE_VERSION=24.18.0
 ARG ALPINE_VERSION=3.22
 ARG MAILCAP_VERSION=2.1.54
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.17.0'
+          node-version: '24.18.0'
           
       - name: Install dependencies
         run: npm install
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.17.0'
+          node-version: '24.18.0'
 
       - name: Build Frontend
         working-directory: webui/frontend
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.17.0'
+          node-version: '24.18.0'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.17.0'
+          node-version: '24.18.0'
 
       - name: Install Frontend Dependencies
         working-directory: webui/frontend

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.17.0'
+          node-version: '24.18.0'
           cache: npm
           cache-dependency-path: website/package-lock.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,11 +116,11 @@ curl -sSL http://localhost:8021                   # Web UI
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
 | `.agents/skills/serve/SKILL.md` | `ec9e4ac` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `e01406e` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/docker-ci/SKILL.md` | `e615c2a` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
 | `.agents/skills/tailscale/SKILL.md` | `e01406e` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `ec9e4ac` | `webui/` |
 | `README.md` | `6f8a583` | `README.md`, `webui/internal/web/server.go`, `docs/openapi.yaml` |
-| `.agents/skills/security-review/SKILL.md` | `e01406e` | `webui/internal/auth/`, `webui/internal/handlers/`, `webui/internal/backup/`, `Dockerfile`, `start.sh` |
+| `.agents/skills/security-review/SKILL.md` | `e615c2a` | `webui/internal/auth/`, `webui/internal/handlers/`, `webui/internal/backup/`, `Dockerfile`, `start.sh` |
 | `.agents/skills/testing-cicd/SKILL.md` | `e01406e` | `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml` |
 | `.agents/skills/documentation/SKILL.md` | `6f8a583` | `README.md`, `CHANGELOG.md`, `webui/README.md`, `AGENTS.md`, `.agents/skills/`, `docs/openapi.yaml`, `website/` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tailscale** bumped from `v1.98.4` to `v1.98.8` in Dockerfile
+- **Node.js** bumped from `24.17.0` to `24.18.0` in Dockerfile and CI workflows
+
 ### Security
 - **Docusaurus dependency upgrades** — resolved 9 Dependabot alerts in `website/` by pinning transitive dependencies to patched versions:
   - `js-yaml` (DoS via merge key aliases, prototype pollution in merge)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
-ARG TAILSCALE_VERSION=v1.98.4
+ARG TAILSCALE_VERSION=v1.98.8
 ARG GO_VERSION=1.26.4
-ARG NODE_VERSION=24.17.0
+ARG NODE_VERSION=24.18.0
 ARG WEBUI_SOURCE=webui-builder
 
 # Frontend build stage — Vite + Svelte + Tailwind


### PR DESCRIPTION
## What
Bumps two pinned dependency versions:
- Tailscale: `v1.98.4` → `v1.98.8`
- Node.js: `24.17.0` → `24.18.0` (Dockerfile ARG + all CI workflow steps)

## Why
Closes both open dependency-update issues:
- closes #44
- closes #35

## Changes
- `Dockerfile`: bump `TAILSCALE_VERSION` and `NODE_VERSION` build args
- `.github/workflows/ci.yml`, `.github/workflows/docs.yml`: bump `node-version` in all steps
- `CHANGELOG.md`: add `### Changed` entry under `[Unreleased]`
- `.agents/skills/docker-ci/SKILL.md`, `.agents/skills/security-review/SKILL.md`: refresh version references and `reviewed_at`
- `AGENTS.md`: advance `reviewed_at` for the two touched skill docs

## Verification
- `docker buildx build --load .` succeeds; `tailscale --version` inside the built image reports `1.98.8`
- `cd webui && go test ./...` passes