### PR TITLE
ci: publish tagged releases to GHCR alongside Docker Hub

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: e615c2a
+reviewed_at: 0671a35
 ---
 
 # Docker & CI Pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -122,6 +123,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -154,6 +162,8 @@ jobs:
           tags: |
             sudocarlos/tailrelay:${{ github.ref_name }}
             sudocarlos/tailrelay:latest
+            ghcr.io/sudocarlos/tailrelay:${{ github.ref_name }}
+            ghcr.io/sudocarlos/tailrelay:latest
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ curl -sSL http://localhost:8021                   # Web UI
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
 | `.agents/skills/serve/SKILL.md` | `ec9e4ac` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `e615c2a` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/docker-ci/SKILL.md` | `0671a35` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
 | `.agents/skills/tailscale/SKILL.md` | `e01406e` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `ec9e4ac` | `webui/` |
 | `README.md` | `6f8a583` | `README.md`, `webui/internal/web/server.go`, `docs/openapi.yaml` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **GHCR release** — CI now also publishes tagged releases to `ghcr.io/sudocarlos/tailrelay` alongside Docker Hub
+
 ### Changed
 - **Tailscale** bumped from `v1.98.4` to `v1.98.8` in Dockerfile
 - **Node.js** bumped from `24.17.0` to `24.18.0` in Dockerfile and CI workflows

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Docker container that exposes local services to your Tailscale network. Combin
 
 ```bash
 docker pull sudocarlos/tailrelay:latest
+# or: docker pull ghcr.io/sudocarlos/tailrelay:latest
 
 docker run -d --name tailrelay \
   -v /path/to/data:/var/lib/tailscale \


### PR DESCRIPTION
## What

Adds GHCR (`ghcr.io/sudocarlos/tailrelay`) as a second push target in the CI `release` job, alongside the existing Docker Hub push.

## Why

The `Makefile`'s `make release` target and `docker-ci/SKILL.md` already documented pushing to both Docker Hub and GHCR, but the actual `ci.yml` release job only pushed to Docker Hub. This brings CI in line with that.

## Changes

- Add `packages: write` permission to the `release` job
- Add a "Log in to GHCR" step (`docker/login-action@v3`, using `github.actor` + `GITHUB_TOKEN` — no new secret needed)
- Add `ghcr.io/sudocarlos/tailrelay:${{ github.ref_name }}` and `:latest` tags to the build-push-action step
- README: mention the GHCR pull alternative
- CHANGELOG: add `[Unreleased]` entry
- Bump `docker-ci/SKILL.md` and `AGENTS.md` `reviewed_at` SHAs

## Verification

- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- No Go/frontend code changed; existing `frontend`/`backend`/`integration` CI jobs are unaffected
- Full push behavior can only be confirmed on an actual `v*.*.*` tag push (requires live secrets)