### PR TITLE
docs: consolidate v0.9.3 release notes and refresh skill review SHAs

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: 0671a35
+reviewed_at: 0a5a4ff
 ---
 
 # Docker & CI Pipeline

--- a/.agents/skills/testing-cicd/SKILL.md
+++ b/.agents/skills/testing-cicd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing-cicd
 description: Writing tests and CI/CD for tailrelay — Go unit tests, Python integration tests, CI pipeline jobs, and test infrastructure. Use when adding new tests, extending the integration suite, modifying ci.yml, or improving test coverage for any Go package or the container behaviour.
-reviewed_at: e01406e
+reviewed_at: 0a5a4ff
 ---
 
 # Tests & CI/CD
@@ -29,9 +29,10 @@ webui/
 │   │   └── backup_test.go              ✓ exists
 │   ├── handlers/
 │   │   ├── auth_test.go                ✓ exists
-│   │   └── backup_test.go              ✓ exists
+│   │   ├── backup_test.go              ✓ exists
+│   │   └── serve_test.go               ✓ exists (HTTPS, TCP, and Funnel relay handlers)
 │   ├── serve/
-│   │   └── manager_test.go             ✓ exists
+│   │   └── manager_test.go             ✓ exists (HTTPS, TCP, and Funnel relay manager)
 │   ├── tailscale/                      ✗ no tests yet
 │   └── web/
 │       └── server_test.go              ✓ exists
@@ -273,9 +274,9 @@ Triggers: push to `main`, push of `v*.*.*` tags, PR to `main`, published release
 
 | Job | Runner | Working Dir | What It Does |
 |-----|--------|-------------|-------------|
-| `frontend` | ubuntu-latest | `webui/frontend` | Node 20 → `npm install` → `npm run build` |
-| `backend` | ubuntu-latest | `webui` | Node 20 + Go 1.24 → `npm install` + `npm run build` (for `//go:embed all:web/dist`) → `go vet ./...` → `go test -v ./...` → `go build -v ./...` |
-| `integration` | ubuntu-latest | repo root | Node 20 + Docker Buildx + Python 3.12 → `pytest tests/integration/ -v` |
+| `frontend` | ubuntu-latest | `webui/frontend` | Node 24.18.0 → `npm install` → `npm run build` |
+| `backend` | ubuntu-latest | `webui` | Node 24.18.0 + Go 1.24 → `npm install` + `npm run build` (for `//go:embed all:web/dist`) → `go vet ./...` → `go test -v ./...` → `go build -v ./...` |
+| `integration` | ubuntu-latest | repo root | Node 24.18.0 + Docker Buildx + Python 3.12 → `pytest tests/integration/ -v` |
 | `release` | ubuntu-latest | repo root | Runs only on `v*.*.*` tags after all three above pass; builds multi-platform image, pushes to Docker Hub + GHCR, creates GitHub Release |
 
 ### Adding a New CI Job
@@ -340,7 +341,7 @@ Example security job:
 |---------|---------|----------|
 | `internal/auth` | ✓ `middleware_test.go` | Maintain |
 | `internal/backup` | ✓ `backup_test.go` | Maintain |
-| `internal/handlers` | ✓ auth, backup | Add: serve, dashboard, tailscale handlers |
+| `internal/handlers` | ✓ auth, backup, serve (HTTPS/TCP/Funnel) | Add: dashboard, tailscale handlers |
 | `internal/web` | ✓ `server_test.go` | Maintain |
 | `internal/serve` | ✓ `manager_test.go` | Maintain; add reconcile edge cases |
 | `internal/tailscale` | ✗ none | **High** |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,12 +116,12 @@ curl -sSL http://localhost:8021                   # Web UI
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
 | `.agents/skills/serve/SKILL.md` | `ec9e4ac` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `0671a35` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/docker-ci/SKILL.md` | `0a5a4ff` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
 | `.agents/skills/tailscale/SKILL.md` | `e01406e` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `ec9e4ac` | `webui/` |
 | `README.md` | `6f8a583` | `README.md`, `webui/internal/web/server.go`, `docs/openapi.yaml` |
 | `.agents/skills/security-review/SKILL.md` | `e615c2a` | `webui/internal/auth/`, `webui/internal/handlers/`, `webui/internal/backup/`, `Dockerfile`, `start.sh` |
-| `.agents/skills/testing-cicd/SKILL.md` | `e01406e` | `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml` |
+| `.agents/skills/testing-cicd/SKILL.md` | `0a5a4ff` | `tests/`, `webui/internal/*/\*_test.go`, `.github/workflows/ci.yml` |
 | `.agents/skills/documentation/SKILL.md` | `6f8a583` | `README.md`, `CHANGELOG.md`, `webui/README.md`, `AGENTS.md`, `.agents/skills/`, `docs/openapi.yaml`, `website/` |
 
 ## Making Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-07-05
+
 ### Added
+- **Tailscale Funnel support** — expose local services to the public internet on ports `443`, `8443`, or `10000` directly from the dashboard
+  - New **Funnel** dashboard section shows a card for each of the three funnel-eligible ports
+  - Free ports show a placeholder card that opens the configure dialog with the port pre-filled
+  - Ports already used by an existing serve relay show a disabled "in use" card
+  - Configured funnel ports support the same lifecycle actions as serve relays: edit, start/stop, autostart, delete
+  - Supports both HTTPS reverse-proxy and raw TCP funnel transports
+  - New `/api/serve/funnel/{list,get,create,update,delete,toggle}` API endpoints
 - **GHCR release** — CI now also publishes tagged releases to `ghcr.io/sudocarlos/tailrelay` alongside Docker Hub
 
 ### Changed
@@ -22,20 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `lodash` (code injection via template, prototype pollution)
   - `yaml` (stack overflow via deeply nested collections)
 
-## [0.9.3] - 2026-07-05
-
-### Added
-- **Tailscale Funnel support** — expose local services to the public internet on ports `443`, `8443`, or `10000` directly from the dashboard
-  - New **Funnel** dashboard section shows a card for each of the three funnel-eligible ports
-  - Free ports show a placeholder card that opens the configure dialog with the port pre-filled
-  - Ports already used by an existing serve relay show a disabled "in use" card
-  - Configured funnel ports support the same lifecycle actions as serve relays: edit, start/stop, autostart, delete
-  - Supports both HTTPS reverse-proxy and raw TCP funnel transports
-  - New `/api/serve/funnel/{list,get,create,update,delete,toggle}` API endpoints
-
 ### Docker
 ```
 docker pull sudocarlos/tailrelay:v0.9.3
+docker pull ghcr.io/sudocarlos/tailrelay:v0.9.3
 ```
 
 ## [0.9.2] - 2026-06-20


### PR DESCRIPTION
## What & why

v0.9.3 was drafted in CHANGELOG.md (with its own version bump and Docker
section) but never actually tagged/released. Three more commits landed
since then with their notes parked under `[Unreleased]` instead of being
folded into the `[0.9.3]` entry:

- GHCR release publishing alongside Docker Hub
- Tailscale v1.98.4 -> v1.98.8, Node 24.17.0 -> 24.18.0 bumps
- Docusaurus dependency security fixes (9 Dependabot alerts)

This PR folds those into the existing `[0.9.3]` entry so the release notes
match everything actually shipping in the image, and corrects stale
content in `testing-cicd/SKILL.md` (Node 20 -> 24.18.0 in the CI table,
serve/Funnel handler test coverage now exists) discovered during the
review.

## Changes

- Merge `[Unreleased]` CHANGELOG bullets into `[0.9.3]`, add GHCR pull
  command to the Docker section
- Fix stale Node version and test coverage claims in
  `.agents/skills/testing-cicd/SKILL.md`
- Bump `reviewed_at` SHAs for `docker-ci` and `testing-cicd` skills and
  their rows in `AGENTS.md`

## Next step

Once merged to `main`, tag `v0.9.3` to trigger the CI release job
(build/test -> multi-arch Docker Hub + GHCR push -> GitHub Release).