### PR TITLE
fix(ci): disable provenance/SBOM attestations for GHCR release push

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: 0a5a4ff
+reviewed_at: 67b91e7
 ---
 
 # Docker & CI Pipeline
@@ -86,10 +86,10 @@ Copy `.env.example` to `.env` and edit before running tests.
 
 ### Jobs
 
-1. **frontend** — `npm install` + `npm run build` in `webui/frontend/` (Node.js 20 in CI)
+1. **frontend** — `npm install` + `npm run build` in `webui/frontend/` (Node.js 24.18.0 in CI)
 2. **backend** — installs Node.js, runs `npm install` + `npm run build` (required for `//go:embed all:web/dist`), then `go vet`, `go test -v`, `go build` in `webui/` (Go 1.24 in CI)
 3. **integration** — Full Docker build + `pytest tests/integration/ -v`
-4. **release** — Runs only on `v*.*.*` tag pushes, after all three above pass; extracts changelog notes, logs in to Docker Hub + GHCR, builds multi-platform image (`linux/amd64`, `linux/arm64`), pushes `vX.Y.Z` + `latest` tags to both registries, and creates a GitHub Release
+4. **release** — Runs only on `v*.*.*` tag pushes, after all three above pass; extracts changelog notes, logs in to Docker Hub + GHCR, builds multi-platform image (`linux/amd64`, `linux/arm64`) with provenance/SBOM attestations disabled (`provenance: false`, `sbom: false` — see Common Pitfalls), pushes `vX.Y.Z` + `latest` tags to both registries, and creates a GitHub Release
 
 ### Integration Test Flow
 
@@ -151,6 +151,8 @@ Handles `SIGTERM`/`SIGINT` for graceful shutdown.
 3. **Docker network**: Use `--net start9` for Start9 deployments to reach embassy services
 4. **TLS certificates**: Must enable HTTPS in Tailscale Admin Console first
 5. **Port conflicts**: Ensure host ports don't conflict with existing services
+6. **GHCR + provenance attestations**: `docker/build-push-action@v6` generates provenance/SBOM attestation manifests by default. Pushing those to a **brand-new** GHCR package (one that's never been published before) fails with `403 Forbidden` on the attestation blob's HEAD request — a known incompatibility, not a permissions bug. The release job sets `provenance: false` / `sbom: false` to avoid it; don't remove these without re-verifying a fresh GHCR package push still works.
+7. **Repo `default_workflow_permissions`**: a job's `permissions:` block can only narrow `GITHUB_TOKEN`, never grant more than the repo's Settings → Actions → General → Workflow permissions default allows. If GHCR pushes or GitHub Release creation start failing with `403`, check `gh api repos/<owner>/<repo>/actions/permissions/workflow` is `write`, not `read`.
 
 ## Bumping Dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
+          sbom: false
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ curl -sSL http://localhost:8021                   # Web UI
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
 | `.agents/skills/serve/SKILL.md` | `ec9e4ac` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `0a5a4ff` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/docker-ci/SKILL.md` | `67b91e7` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
 | `.agents/skills/tailscale/SKILL.md` | `e01406e` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `ec9e4ac` | `webui/` |
 | `README.md` | `6f8a583` | `README.md`, `webui/internal/web/server.go`, `docs/openapi.yaml` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tailscale** bumped from `v1.98.4` to `v1.98.8` in Dockerfile
 - **Node.js** bumped from `24.17.0` to `24.18.0` in Dockerfile and CI workflows
 
+### Fixed
+- **GHCR publish failure** — disabled provenance/SBOM attestations on the release Docker build, which GHCR rejected with a `403` when pushing to the brand-new `ghcr.io/sudocarlos/tailrelay` package
+
 ### Security
 - **Docusaurus dependency upgrades** — resolved 9 Dependabot alerts in `website/` by pinning transitive dependencies to patched versions:
   - `js-yaml` (DoS via merge key aliases, prototype pollution in merge)


### PR DESCRIPTION
## What & why

Tagging and pushing v0.9.3 revealed that `docker/build-push-action@v6`'s
default provenance/SBOM attestation manifests are rejected by GHCR with a
`403 Forbidden` on the first-ever push of a brand-new container package
(`ghcr.io/sudocarlos/tailrelay` didn't exist before this release). Docker
Hub pushed fine; GHCR failed specifically on the attestation manifest's
blob HEAD check. This is a known `docker/build-push-action` + GHCR
incompatibility, not a permissions bug — a repo-level
`default_workflow_permissions` setting was also flipped from `read` to
`write` while diagnosing this (ci.yml already declared `packages: write`
at the job level, but that can only narrow, never exceed, the repo
default).

## Changes

- `ci.yml`: add `provenance: false` and `sbom: false` to the release
  job's `docker/build-push-action@v6` step
- `docker-ci/SKILL.md`: document both gotchas (GHCR + provenance,
  `default_workflow_permissions` capping job-level permissions), fix
  stale "Node 20" reference, bump `reviewed_at`
- `CHANGELOG.md`: add a `### Fixed` bullet to the `[0.9.3]` entry
- `AGENTS.md`: advance the `docker-ci/SKILL.md` review SHA

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML
- Once merged, the `v0.9.3` tag will be moved to the new `main` HEAD and
  re-pushed to retry the full release (Docker Hub + GHCR + GitHub
  Release)