### PR TITLE
fix(webui): proxy toggle uses running state instead of proxy.enabled

### DIFF
--- a/webui/frontend/src/lib/components/Dashboard.svelte
+++ b/webui/frontend/src/lib/components/Dashboard.svelte
@@ -134,7 +134,7 @@
         const entry = findItem(type, id);
         const actualRunning = type === 'relay'
           ? get(relays).find((r) => r.relay.id === id)?.running
-          : (entry?.enabled ?? false);
+          : (entry?.running ?? false);
         if (actualRunning === expected) break;
         await new Promise((r) => setTimeout(r, 500));
       }

--- a/webui/frontend/src/lib/components/ItemCard.svelte
+++ b/webui/frontend/src/lib/components/ItemCard.svelte
@@ -113,7 +113,7 @@
         <Toggle
           checked={running}
           disabled={toggling}
-          onChange={() => onToggle('proxy', proxy.id, proxy.enabled)}
+          onChange={() => onToggle('proxy', proxy.id, running)}
           label={running ? 'Stop proxy' : 'Start proxy'}
         />
         <ItemMenu


### PR DESCRIPTION
## Summary

Fix the HTTPS proxy toggle to use the live `running` state instead of the
persisted `enabled` flag, matching the behavior of relay and funnel toggles.
This prevents the toggle from flipping in the wrong direction when the desired
and actual states diverge (e.g., during reconciliation or daemon delay).

## Changes

- **ItemCard.svelte**: proxy toggle `onChange` passes `running` instead of
  `proxy.enabled`, matching relay and funnel card behavior
- **Dashboard.svelte**: toggle polling in `handleToggleAction` checks `.running`
  for proxy/funnel instead of `.enabled`, so the polling loop waits for the
  live daemon state to converge (consistent with how the relay branch already
  works)

## Related

Closes #58