### PR TITLE
build: support native arch and podman in dev builds

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: 67b91e7
+reviewed_at: a93bcfa
 ---
 
 # Docker & CI Pipeline
@@ -42,6 +42,10 @@ make dev-docker-build    # Build Docker image using local binary
 
 `dev-docker-build` passes `--build-arg WEBUI_SOURCE=binary-dev` so Docker copies `./data/tailrelay-webui` from the build context instead of compiling in-container. No separate `Dockerfile.dev` is needed.
 
+Both `dev-build` and `dev-docker-build` default `GOARCH` to the host's native architecture (via `go env GOARCH`), and `dev-docker-build` passes it through as `--platform linux/$(GOARCH)`. On Apple Silicon this builds a native `linux/arm64` binary/image with no QEMU emulation. Override with `make dev-docker-build GOARCH=amd64` to cross-build for a different arch.
+
+`dev-docker-build` and `release` also auto-detect the container engine via `CONTAINER_ENGINE ?= $(shell command -v docker ... || echo podman)`, so podman-only setups (no `docker` binary — a shell `alias docker=podman` isn't visible to Make's non-interactive recipe shell) work without edits. `BUILDX_LOAD` adds `--load` only for docker, since podman's `buildx build` shim always loads locally and rejects that flag. Override with `make dev-docker-build CONTAINER_ENGINE=podman` if detection picks the wrong engine. Podman's `buildx build` compatibility shim ships with recent Podman Desktop/CLI releases (verified against podman 6.0.1) but isn't guaranteed on every install — a "command not found" here means the podman install lacks the shim, not a bug in the detection logic. `make release`'s multi-platform `--push` hasn't been exercised against podman; if it doesn't push cleanly, run it with `CONTAINER_ENGINE=docker` instead.
+
 ## Make Targets
 
 | Target | Description | Depends On |
@@ -50,8 +54,8 @@ make dev-docker-build    # Build Docker image using local binary
 | `make test` | Run Go unit tests (`cd webui && go test ./...`) | — |
 | `make integration-test` | Run integration tests via pytest | Docker, `.env` |
 | `make frontend-build` | Build SPA assets (npm install + build) | Node.js |
-| `make dev-build` | Build Go binary with metadata | `frontend-build` |
-| `make dev-docker-build` | Build dev Docker image | `dev-build` |
+| `make dev-build` | Build Go binary with metadata (native `GOARCH` by default) | `frontend-build` |
+| `make dev-docker-build` | Build dev Docker image for native host platform (`linux/$(GOARCH)`) | `dev-build` |
 | `make release` | Multi-platform push to Docker Hub + GHCR | Docker Buildx |
 | `make clean` | Remove build artifacts | — |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ curl -sSL http://localhost:8021                   # Web UI
 | `AGENTS.md` | `HEAD` | `AGENTS.md`, `Makefile`, `start.sh` |
 | `.agents/skills/serve/SKILL.md` | `ec9e4ac` | `webui/internal/serve/`, `webui/internal/handlers/serve.go` |
 | `.agents/skills/webui/SKILL.md` | `e01406e` | `webui/`, `Makefile` |
-| `.agents/skills/docker-ci/SKILL.md` | `67b91e7` | `Dockerfile`, `.github/workflows/`, `compose-test.yml` |
+| `.agents/skills/docker-ci/SKILL.md` | `67b91e7` | `Dockerfile`, `.github/workflows/`, `compose-test.yml`, `Makefile` |
 | `.agents/skills/tailscale/SKILL.md` | `06c104a` | `webui/internal/tailscale/`, `start.sh` |
 | `webui/README.md` | `ec9e4ac` | `webui/` |
 | `README.md` | `6f8a583` | `README.md`, `webui/internal/web/server.go`, `docs/openapi.yaml` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`make dev-docker-build`/`make release`** — auto-detect the container engine (`docker` or `podman`) instead of hardcoding `docker`, since a shell `alias docker=podman` isn't visible to Make's non-interactive recipe shell. `dev-build`/`dev-docker-build` also now default `GOARCH`/`--platform` to the host's native architecture (`go env GOARCH`) instead of relying on implicit defaults, so builds on Apple Silicon are native `linux/arm64` with no QEMU emulation.
+
 ## [0.9.5] - 2026-07-14
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,18 @@ DOCKERHUB_REPO ?= sudocarlos/tailrelay
 GHCR_REPO ?= ghcr.io/sudocarlos/tailrelay
 PLATFORMS ?= linux/amd64,linux/arm64
 
+# Host architecture (e.g. arm64 on Apple Silicon, amd64 on Intel/most Linux)
+# used to build native dev binaries/images instead of relying on emulation.
+GOARCH ?= $(shell go env GOARCH)
+
+# Container engine: prefers docker, falls back to podman (aliases aren't
+# visible to Make's non-interactive shell). Override: CONTAINER_ENGINE=podman
+CONTAINER_ENGINE ?= $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
+
+# docker's buildx needs --load to load the image locally; podman's buildx
+# shim always loads locally and rejects --load outright.
+BUILDX_LOAD := $(if $(filter docker,$(CONTAINER_ENGINE)),--load,)
+
 # Go build flags with metadata
 LDFLAGS = -w -s \
 	-X main.Version=$(VERSION) \
@@ -45,8 +57,9 @@ dev-build: frontend-build ## Build webui binary locally for development
 	@echo "  DATE:    $(DATE)"
 	@echo "  BRANCH:  $(BRANCH)"
 	@echo "  BUILDER: $(BUILDER)"
+	@echo "  GOARCH:  $(GOARCH)"
 	@mkdir -p data
-	cd webui && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+	cd webui && CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -a -installsuffix cgo \
 		-ldflags="$(LDFLAGS)" \
 		-o ../data/tailrelay-webui ./cmd/webui
 	@if [ -f data/tailrelay-webui ]; then \
@@ -57,9 +70,9 @@ dev-build: frontend-build ## Build webui binary locally for development
 		exit 1; \
 	fi
 
-dev-docker-build: dev-build ## Build development Docker image using local binary
-	@echo "Building development Docker image..."
-	docker buildx build --load --build-arg WEBUI_SOURCE=binary-dev -t sudocarlos/tailrelay:dev -t sudocarlos/tailrelay:dev-$(COMMIT) .
+dev-docker-build: dev-build ## Build development Docker image using local binary (native host arch)
+	@echo "Building development image for linux/$(GOARCH) with $(CONTAINER_ENGINE)..."
+	$(CONTAINER_ENGINE) buildx build $(BUILDX_LOAD) --platform linux/$(GOARCH) --build-arg WEBUI_SOURCE=binary-dev -t sudocarlos/tailrelay:dev -t sudocarlos/tailrelay:dev-$(COMMIT) .
 	@echo "✅ Development image built and loaded: sudocarlos/tailrelay:dev and sudocarlos/tailrelay:dev-$(COMMIT)"
 
 clean: ## Remove build artifacts
@@ -78,7 +91,7 @@ release: ## Build and push multi-platform release to Docker Hub + GHCR
 	@echo "  Platforms: $(PLATFORMS)"
 	@echo "  Docker Hub: $(DOCKERHUB_REPO):$(VERSION)"
 	@echo "  GHCR:       $(GHCR_REPO):$(VERSION)"
-	docker buildx build \
+	$(CONTAINER_ENGINE) buildx build \
 		--platform $(PLATFORMS) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) \


### PR DESCRIPTION
## What & why

Closes #67

`make dev-docker-build` broke on podman-only setups (no `docker` binary,
just a shell `alias docker=podman`) because Make recipes run in a
non-interactive shell that never sees interactive-shell aliases.

## Changes

- Add `GOARCH ?= $(shell go env GOARCH)` and thread it through `dev-build`
  (explicit `GOARCH=$(GOARCH)` in the `go build` invocation) and
  `dev-docker-build` (`--platform linux/$(GOARCH)`), so the local binary and
  image target always match the host's native architecture (e.g. `arm64` on
  Apple Silicon) instead of relying on implicit defaults or the buildx
  builder's platform.
- Add `CONTAINER_ENGINE ?= $(shell command -v docker ... || echo podman)` —
  auto-detects a real `docker` binary, falls back to `podman`. Overridable
  via `make dev-docker-build CONTAINER_ENGINE=podman`.
- Add `BUILDX_LOAD` that only appends `--load` for docker, since podman's
  `buildx build` shim always loads locally and rejects `--load`.
- Apply `$(CONTAINER_ENGINE)` to both `dev-docker-build` and `release`.
- Document the new defaults/overrides in `.agents/skills/docker-ci/SKILL.md`.

## Verification

- `make dev-build` — correctly reports/uses `GOARCH: arm64` on Apple Silicon.
- `make -n dev-docker-build` / `make -n release` — dry-run confirms the
  generated commands pick `podman` (no `docker` on `PATH`) with no `--load`.
- `make dev-docker-build` run end-to-end with podman 6.0.1 — image built
  successfully; `podman inspect ... → linux/arm64` confirms native arch, no
  emulation.
- `cd webui && go test ./...` — all packages pass.