### PR TITLE
chore: update Tailscale from v1.98.8 to v1.98.9

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -26,7 +26,7 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 5. **main** (`ghcr.io/tailscale/tailscale:{TAILSCALE_VERSION}`) — based on the official Tailscale image; installs runtime deps (iptables, iproute2, mailcap), copies webui binary from builder stage; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
-- `TAILSCALE_VERSION` (default: `v1.98.8`) — image tag for `ghcr.io/tailscale/tailscale`
+- `TAILSCALE_VERSION` (default: `v1.98.9`) — image tag for `ghcr.io/tailscale/tailscale`
 - `GO_VERSION` (default: `1.26.5`)
 - `NODE_VERSION` (default: `24.18.0`)
 - `ALPINE_VERSION` (default: `3.22`)
@@ -190,6 +190,6 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Component | Version |
 |-----------|---------|
 | Container | `v0.9.0` (see `start.sh`) |
-| Tailscale | `v1.98.8` (`ghcr.io/tailscale/tailscale` base image) |
+| Tailscale | `v1.98.9` (`ghcr.io/tailscale/tailscale` base image) |
 | Go | `1.26.5` (Dockerfile ARG) |
 | Node.js (CI) | `24.18.0` (GitHub Actions + Dockerfile ARG) |

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -34,7 +34,7 @@ tailrelay combines two networked services (Tailscale and a Go Web UI) inside a s
 All versions are pinned as `ARG` values at the top of `Dockerfile`:
 
 ```
-ARG TAILSCALE_VERSION=v1.98.8
+ARG TAILSCALE_VERSION=v1.98.9
 ARG GO_VERSION=1.26.5
 ARG NODE_VERSION=24.18.0
 ARG ALPINE_VERSION=3.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Tailscale** bumped from `v1.98.8` to `v1.98.9` in Dockerfile
 - **Frontend tooling** — bumped `vite` in `webui/frontend/package.json` from `8.1.4` to `8.1.5`
 - **Go** bumped from `1.26.4` to `1.26.5` in Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
-ARG TAILSCALE_VERSION=v1.98.8
+ARG TAILSCALE_VERSION=v1.98.9
 ARG GO_VERSION=1.26.5
 ARG NODE_VERSION=24.18.0
 ARG WEBUI_SOURCE=webui-builder


### PR DESCRIPTION
Bumps the pinned Tailscale version from v1.98.8 to v1.98.9.

## Changes

- **Dockerfile** — `TAILSCALE_VERSION` ARG updated to `v1.98.9`
- **CHANGELOG.md** — added version bump entry under `[Unreleased]`
- **docker-ci SKILL.md** — updated default version + version table
- **security-review SKILL.md** — updated pinned version example

## Verification

- [ ] CI passes (`docker buildx build` succeeds against the new image tag)
- [ ] No breaking changes in [v1.98.9 release notes](https://github.com/tailscale/tailscale/releases/tag/v1.98.9)

closes #71