### PR TITLE
ci(docs): trigger on screenshot changes and verify mirror

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'website/**'
       - 'docs/openapi.yaml'
+      - 'docs/screenshots/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -26,6 +27,13 @@ jobs:
         working-directory: website
     steps:
       - uses: actions/checkout@v4
+
+      # The capture script mirrors docs/screenshots/ into the site's static dir,
+      # but only the mirrored copy is published. Fail loudly on drift rather
+      # than deploying stale images that look fine.
+      - name: Verify screenshots are mirrored
+        working-directory: ${{ github.workspace }}
+        run: diff -rq --exclude='*.mjs' --exclude='node_modules' docs/screenshots website/static/img/screenshots
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What

Closes the trigger gap noticed while shipping #80.

## Why

`docs.yml` watched `website/**`, `docs/openapi.yaml` and itself. Screenshot sources live in `docs/screenshots/`, so a change confined to that directory would **not** redeploy the site. #80 only redeployed because the capture script mirrors each PNG into `website/static/img/screenshots/`.

That mirroring is a convention, not an enforced invariant. If the two directories drift — someone edits a source without re-running the script, or copies a PNG in by hand — the site keeps serving the stale mirrored copy, and nothing fails. The images look perfectly valid, so the drift is invisible in review.

## Changes

- add `docs/screenshots/**` to the workflow's trigger paths
- add a `diff -rq` step (before the Node setup, so it fails fast) comparing `docs/screenshots/` against `website/static/img/screenshots/`, excluding the capture script and the gitignored `node_modules` symlink

The two changes are complementary: the trigger makes a screenshot-only commit reach CI, and the diff gives that run something meaningful to assert — otherwise it would just rebuild an unchanged site and pass.

## Verified

- YAML parses
- `diff -rq` reports the current tree as in sync (exit 0)
- confirmed the same command exits 1 on two deliberately different PNGs, so drift genuinely fails the build