### PR TITLE
chore: update Tailscale from v1.98.10 to v1.102.2

### DIFF
--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -26,7 +26,7 @@ docker buildx build -t sudocarlos/tailrelay:latest --load .
 5. **main** (`ghcr.io/tailscale/tailscale:{TAILSCALE_VERSION}`) — based on the official Tailscale image; installs runtime deps (iptables, iproute2, mailcap), copies webui binary from builder stage; restores legacy iptables symlinks for broad host compatibility
 
 Key build args:
-- `TAILSCALE_VERSION` (default: `v1.98.10`) — image tag for `ghcr.io/tailscale/tailscale`
+- `TAILSCALE_VERSION` (default: `v1.102.2`) — image tag for `ghcr.io/tailscale/tailscale`
 - `GO_VERSION` (default: `1.26.5`)
 - `NODE_VERSION` (default: `24.19.0`)
 - `ALPINE_VERSION` (default: `3.22`)
@@ -190,6 +190,6 @@ When updating a pinned version in the Dockerfile, touch every location in the ta
 | Component | Version |
 |-----------|---------|
 | Container | `v0.9.0` (see `start.sh`) |
-| Tailscale | `v1.98.10` (`ghcr.io/tailscale/tailscale` base image) |
+| Tailscale | `v1.102.2` (`ghcr.io/tailscale/tailscale` base image) |
 | Go | `1.26.5` (Dockerfile ARG) |
 | Node.js (CI) | `24.19.0` (GitHub Actions + Dockerfile ARG) |

--- a/.agents/skills/docker-ci/SKILL.md
+++ b/.agents/skills/docker-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docker-ci-pipeline
 description: Docker image building, Compose development environments, CI/CD pipeline, and testing infrastructure. Use when working with Dockerfiles, docker-compose, GitHub Actions CI, Make targets, integration tests, or deployment workflows.
-reviewed_at: 5cc8dc5
+reviewed_at: 39911f4
 ---
 
 # Docker & CI Pipeline

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-review
 description: Security and privacy review for tailrelay — dependency CVE scanning, Go module auditing, auth review, and code-level vulnerability checks. Use when reviewing code for security issues, auditing Dockerfile dependencies, checking for secrets/injection risks, or assessing privacy of logged/persisted data.
-reviewed_at: f2c24a0
+reviewed_at: 39911f4
 ---
 
 # Security & Privacy Review

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -34,7 +34,7 @@ tailrelay combines two networked services (Tailscale and a Go Web UI) inside a s
 All versions are pinned as `ARG` values at the top of `Dockerfile`:
 
 ```
-ARG TAILSCALE_VERSION=v1.98.10
+ARG TAILSCALE_VERSION=v1.102.2
 ARG GO_VERSION=1.26.5
 ARG NODE_VERSION=24.19.0
 ARG ALPINE_VERSION=3.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Tailscale** bumped from `v1.98.10` to `v1.102.2` in Dockerfile
 - **Tailscale** bumped from `v1.98.9` to `v1.98.10` in Dockerfile
 - **Node.js** bumped from `24.18.1` to `24.19.0` in Dockerfile and CI
 - **Frontend tooling** — bumped `vite` in `webui/frontend/package.json` from `8.1.5` to `8.2.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
-ARG TAILSCALE_VERSION=v1.98.10
+ARG TAILSCALE_VERSION=v1.102.2
 ARG GO_VERSION=1.26.5
 ARG NODE_VERSION=24.19.0
 ARG WEBUI_SOURCE=webui-builder


### PR DESCRIPTION
## Summary

Bumps the base Tailscale image from `v1.98.10` to the current stable `v1.102.2`.

Following the "Bumping Dependencies" checklist in `.agents/skills/docker-ci/SKILL.md`, every pinned-version location is touched:

- `Dockerfile` — `ARG TAILSCALE_VERSION=v1.102.2`
- `.agents/skills/docker-ci/SKILL.md` — Version Information table
- `.agents/skills/security-review/SKILL.md` — Pinned Versions block
- `CHANGELOG.md` — `### Changed` entry under `[Unreleased]`

`docker-ci/SKILL.md` and `security-review/SKILL.md` `reviewed_at` advanced to the bump commit.

Closes #95.

## Verification

- `make frontend-build` — builds SPA assets cleanly (Vite v8.2.0)
- `cd webui && go test ./...` — all packages pass

The Docker image itself isn't rebuilt here (integration build needs Docker + `.env`); the change is a single image-tag ARG bump with no other Dockerfile logic affected.
