### PR TITLE
chore(webui): update Vite from 8.2.0 to 8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Frontend tooling** — bumped `vite` in `webui/frontend/package.json` from `8.2.0` to `8.2.1`
 - **Tailscale** bumped from `v1.98.10` to `v1.102.2` in Dockerfile
 - **Tailscale** bumped from `v1.98.9` to `v1.98.10` in Dockerfile
 - **Node.js** bumped from `24.18.1` to `24.19.0` in Dockerfile and CI

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "svelte": "^5.53.7",
         "tailwindcss": "^4.2.1",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1911,16 +1911,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/webui/frontend/package.json
+++ b/webui/frontend/package.json
@@ -14,7 +14,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "svelte": "^5.53.7",
     "tailwindcss": "^4.2.1",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   },
   "dependencies": {
     "jsdom": "^28.1.0",


### PR DESCRIPTION
## Summary

Bumps Vite from `8.2.0` to `8.2.1` (a patch release — bug fixes in build chunkImportMap, CSS minify, server port handling, and a rolldown deps bump; no breaking changes).

- `webui/frontend/package.json` — `"vite": "^8.2.1"`
- `webui/frontend/package-lock.json` — regenerated via `npm install`
- `CHANGELOG.md` — `### Changed` entry under `[Unreleased]`, matching the wording of prior Vite bumps (`b8812d4`)

Closes #94.

## Verification

- `npm audit` — 0 vulnerabilities
- `make frontend-build` — builds cleanly with `vite v8.2.1` (3795 modules transformed)
- `cd webui && go test ./...` — all packages pass

The built SPA asset content is byte-identical to the previous build (same `index-*.js`/`index-*.css` hashes), so the Go `//go:embed all:web/dist` build is unaffected; no dist changes are committed.
